### PR TITLE
modernize junit5 usage

### DIFF
--- a/mjsip-examples/src/test/java/org/mjsip/examples/TestAudioApp.java
+++ b/mjsip-examples/src/test/java/org/mjsip/examples/TestAudioApp.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link AudioApp}.
  */
-public class TestAudioApp {
+class TestAudioApp {
 	
 	@Test
-	public void testSendReceive() throws IOException {
+	void testSendReceive() throws IOException {
 		File rx = File.createTempFile("rx-audio", ".wav");
 		
 		AudioApp.main(new String[] {

--- a/mjsip-net/src/test/java/test/org/zoolu/net/TestIpAddress.java
+++ b/mjsip-net/src/test/java/test/org/zoolu/net/TestIpAddress.java
@@ -12,10 +12,10 @@ import org.zoolu.net.IpAddress;
 /**
  * Test case for {@link IpAddress}.
  */
-public class TestIpAddress {
+class TestIpAddress {
 
 	@Test
-	public void testAutoConfig() throws UnknownHostException {
+	void testAutoConfig() throws UnknownHostException {
 		InetAddress ipv4 = IpAddress.getLocalHostAddress(AddressType.IP4);
 		InetAddress ipv6 = IpAddress.getLocalHostAddress(AddressType.IP6);
 		

--- a/mjsip-sip/src/test/java/org/mjsip/sip/address/TestSipURI.java
+++ b/mjsip-sip/src/test/java/org/mjsip/sip/address/TestSipURI.java
@@ -16,24 +16,24 @@ import org.junit.jupiter.api.Test;
  * Test for {@link SipURI} parsing.
  */
 @SuppressWarnings("javadoc")
-public class TestSipURI {
+class TestSipURI {
 
 	@Test
-	public void testCreate() {
+	void testCreate() {
 		SipURI uri = new SipURI("alice", "foobar", "phoneblock.net", 55060, false, Collections.singletonMap("p", "v"),
 				null);
 		Assertions.assertEquals("sip:alice:foobar@phoneblock.net:55060;p=v", uri.toString());
 	}
 
 	@Test
-	public void testCreateIPv6() {
+	void testCreateIPv6() {
 		SipURI uri = new SipURI("alice", "foobar", "fe80::43c6:1e57:8a59:ce55", 55060, false,
 				Collections.singletonMap("p", "v"), null);
 		Assertions.assertEquals("sip:alice:foobar@[fe80::43c6:1e57:8a59:ce55]:55060;p=v", uri.toString());
 	}
 
 	@Test
-	public void testParse() {
+	void testParse() {
 		SipURI uri = SipURI.parseSipURI("host.only");
 		Assertions.assertEquals("sip", uri.getScheme());
 		Assertions.assertFalse(uri.isSecure());
@@ -41,7 +41,7 @@ public class TestSipURI {
 	}
 
 	@Test
-	public void testSip() {
+	void testSip() {
 		SipURI uri = SipURI.parseSipURI("sip:host.only");
 		Assertions.assertEquals("sip", uri.getScheme());
 		Assertions.assertFalse(uri.isSecure());
@@ -49,7 +49,7 @@ public class TestSipURI {
 	}
 
 	@Test
-	public void testParseSips() {
+	void testParseSips() {
 		SipURI uri = SipURI.parseSipURI("sips:host.only");
 		Assertions.assertEquals("sips", uri.getScheme());
 		Assertions.assertTrue(uri.isSecure());
@@ -57,14 +57,14 @@ public class TestSipURI {
 	}
 
 	@Test
-	public void testParsePort() {
+	void testParsePort() {
 		SipURI uri = SipURI.parseSipURI("host.only:5060");
 		Assertions.assertEquals("host.only", uri.getHost());
 		Assertions.assertEquals(5060, uri.getPort());
 	}
 
 	@Test
-	public void testParseUser() {
+	void testParseUser() {
 		SipURI uri = SipURI.parseSipURI("foo@host.only:5060");
 		Assertions.assertEquals("foo", uri.getUserName());
 		Assertions.assertEquals("host.only", uri.getHost());
@@ -72,7 +72,7 @@ public class TestSipURI {
 	}
 
 	@Test
-	public void testParsePassword() {
+	void testParsePassword() {
 		SipURI uri = SipURI.parseSipURI("foo:secure@host.only:5060");
 		Assertions.assertEquals("foo", uri.getUserName());
 		Assertions.assertEquals("secure", uri.getPassword());
@@ -81,7 +81,7 @@ public class TestSipURI {
 	}
 
 	@Test
-	public void testParsePasswordWithoutPort() {
+	void testParsePasswordWithoutPort() {
 		SipURI uri = SipURI.parseSipURI("foo:secure@host.only");
 		Assertions.assertEquals("foo", uri.getUserName());
 		Assertions.assertEquals("secure", uri.getPassword());
@@ -90,15 +90,15 @@ public class TestSipURI {
 	}
 
 	@Test
-	public void testParseParamWithoutValue() {
+	void testParseParamWithoutValue() {
 		SipURI uri = SipURI.parseSipURI("host.only;param");
 		Assertions.assertEquals("host.only", uri.getHost());
 		Assertions.assertTrue(uri.hasParameter("param"));
-		Assertions.assertEquals(null, uri.getParameter("param"));
+        Assertions.assertNull(uri.getParameter("param"));
 	}
 
 	@Test
-	public void testParseParam() {
+	void testParseParam() {
 		SipURI uri = SipURI.parseSipURI("host.only;key=value");
 		Assertions.assertEquals("host.only", uri.getHost());
 		Assertions.assertTrue(uri.hasParameter("key"));
@@ -106,27 +106,27 @@ public class TestSipURI {
 	}
 
 	@Test
-	public void testIPv6() {
+	void testIPv6() {
 		SipURI uri = SipURI.parseSipURI("[fe80::43c6:1e57:8a59:ce55]");
 		Assertions.assertEquals("fe80::43c6:1e57:8a59:ce55", uri.getHost());
 	}
 
 	@Test
-	public void testIPv6WithPort() {
+	void testIPv6WithPort() {
 		SipURI uri = SipURI.parseSipURI("[fe80::43c6:1e57:8a59:ce55]:5060");
 		Assertions.assertEquals("fe80::43c6:1e57:8a59:ce55", uri.getHost());
 		Assertions.assertEquals(5060, uri.getPort());
 	}
 
 	@Test
-	public void testIPv6WithUser() {
+	void testIPv6WithUser() {
 		SipURI uri = SipURI.parseSipURI("foo@[fe80::43c6:1e57:8a59:ce55]");
 		Assertions.assertEquals("foo", uri.getUserName());
 		Assertions.assertEquals("fe80::43c6:1e57:8a59:ce55", uri.getHost());
 	}
 
 	@Test
-	public void testIPv6WithPortAndUser() {
+	void testIPv6WithPortAndUser() {
 		SipURI uri = SipURI.parseSipURI("foo:secure@[fe80::43c6:1e57:8a59:ce55]:5060");
 		Assertions.assertEquals("foo", uri.getUserName());
 		Assertions.assertEquals("secure", uri.getPassword());
@@ -135,7 +135,7 @@ public class TestSipURI {
 	}
 
 	@Test
-	public void testIPv6WithUserAndParam() {
+	void testIPv6WithUserAndParam() {
 		SipURI uri = SipURI.parseSipURI("foo@[fe80::43c6:1e57:8a59:ce55]:5060;key0=value0;key1");
 		Assertions.assertEquals("foo", uri.getUserName());
 		Assertions.assertEquals("fe80::43c6:1e57:8a59:ce55", uri.getHost());
@@ -145,7 +145,7 @@ public class TestSipURI {
 	}
 
 	@Test
-	public void testRandom() {
+	void testRandom() {
 		Random rnd = new Random(42);
 		for (int n = 0; n < 1024; n++) {
 			StringBuilder buffer = new StringBuilder();
@@ -160,7 +160,7 @@ public class TestSipURI {
 		}
 	}
 
-	public static TestPart[] PARTS = { new TestUser(), new TestHost(), new TestPort(), new TestParam(),
+	private static final TestPart[] PARTS = { new TestUser(), new TestHost(), new TestPort(), new TestParam(),
 			new TestHeader() };
 
 	static abstract class TestPart {

--- a/mjsip-sip/src/test/java/org/mjsip/sip/authentication/TestDigestAuthentication.java
+++ b/mjsip-sip/src/test/java/org/mjsip/sip/authentication/TestDigestAuthentication.java
@@ -11,10 +11,10 @@ import org.mjsip.sip.header.AuthorizationHeader;
  * Test for {@link DigestAuthentication}.
  */
 @SuppressWarnings("javadoc")
-public class TestDigestAuthentication {
+class TestDigestAuthentication {
 
 	@Test
-	public void testResponse() {
+	void testResponse() {
 		AuthorizationHeader ah = new AuthorizationHeader(
 				"Digest username=\"Mufasa\", "
 				+ "realm=\"testrealm@host.com\", " 

--- a/mjsip-sip/src/test/java/test/org/mjsip/sdp/field/TestConnectionField.java
+++ b/mjsip-sip/src/test/java/test/org/mjsip/sdp/field/TestConnectionField.java
@@ -11,10 +11,10 @@ import org.zoolu.net.AddressType;
 /**
  * Test for {@link ConnectionField}
  */
-public class TestConnectionField {
+class TestConnectionField {
 
 	@Test
-	public void testParse() {
+	void testParse() {
 		ConnectionField field = new ConnectionField("IN IP6 2001:9e8:2050:becc:7eff:4dff:fe57:1a5a");
 
 		Assertions.assertEquals(AddressType.IP6, field.getAddressType());

--- a/mjsip-sip/src/test/java/test/org/mjsip/sip/header/TestViaHeader.java
+++ b/mjsip-sip/src/test/java/test/org/mjsip/sip/header/TestViaHeader.java
@@ -5,15 +5,17 @@ package test.org.mjsip.sip.header;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mjsip.sip.header.ViaHeader;
 
 /**
  * Test for {@link ViaHeader}.
  */
-public class TestViaHeader {
+class TestViaHeader {
 
 	@Test
-	public void testParse() {
+	void testParse() {
 		ViaHeader header = ViaHeader
 				.parse("SIP/2.0/UDP [2001:9e8:2050:becc:7eff:4dff:fe57:1a5a]:5060;branch=z9hG4bK0D731C24CCBB2565");
 
@@ -27,7 +29,7 @@ public class TestViaHeader {
 	}
 
 	@Test
-	public void testWhiteSpace() {
+	void testWhiteSpace() {
 		ViaHeader header = ViaHeader
 				.parse("SIP/2.0/UDP   phoneblock.net	: 	5060   ;  branch =    z9hG4bK0D731C24CCBB2565    ");
 
@@ -35,17 +37,18 @@ public class TestViaHeader {
 	}
 
 	@Test
-	public void testNoPort() {
+	void testNoPort() {
 		doTestValue("SIP/2.0/UDP phoneblock.net;branch=z9hG4bK0D731C24CCBB2565");
 	}
 
-	@Test
-	public void testRPort() {
-		doTestValue("SIP/2.0/UDP phoneblock.net;branch=z9hG4bK0D731C24CCBB2565;rport");
-		doTestValue("SIP/2.0/UDP phoneblock.net;rport;branch=z9hG4bK0D731C24CCBB2565");
+	@ParameterizedTest
+	@ValueSource(strings = {"SIP/2.0/UDP phoneblock.net;branch=z9hG4bK0D731C24CCBB2565;rport",
+			"SIP/2.0/UDP phoneblock.net;rport;branch=z9hG4bK0D731C24CCBB2565"})
+	void testRPort(String value) {
+		doTestValue(value);
 	}
 
-	private void doTestValue(String value) {
+	private static void doTestValue(String value) {
 		ViaHeader header = ViaHeader.parse(value);
 		Assertions.assertEquals(value, header.getValue());
 	}

--- a/mjsip-sip/src/test/java/test/org/zoolu/sound/TestSimpleAudioSystem.java
+++ b/mjsip-sip/src/test/java/test/org/zoolu/sound/TestSimpleAudioSystem.java
@@ -24,10 +24,10 @@ import org.zoolu.sound.codec.G711;
 /**
  * Test generating, and transforming WAV files.
  */
-public class TestSimpleAudioSystem {
+class TestSimpleAudioSystem {
 
 	@Test
-	public void testToneWavLinearSigned() throws IOException, UnsupportedAudioFileException {
+	void testToneWavLinearSigned() throws IOException, UnsupportedAudioFileException {
 		int sampleRate = 16000;
 		int sampleSize = 2;
 		boolean bigEndian = false;
@@ -45,7 +45,7 @@ public class TestSimpleAudioSystem {
 	}
 
 	@Test
-	public void testToneWavAlaw() throws IOException, UnsupportedAudioFileException {
+	void testToneWavAlaw() throws IOException, UnsupportedAudioFileException {
 		int sampleRate = 16000;
 		int sampleSize = 2;
 		int duration = 1;

--- a/mjsip-sound/pom.xml
+++ b/mjsip-sound/pom.xml
@@ -15,12 +15,5 @@
 		<artifactId>mjsip-util</artifactId>
 		<version>1.9.0-SNAPSHOT</version>
 	</dependency>
-
-	<dependency>
-	    <groupId>org.junit.jupiter</groupId>
-	    <artifactId>junit-jupiter-api</artifactId>
-	    <version>5.9.3</version>
-	    <scope>test</scope>
-	</dependency>
   </dependencies>
 </project>

--- a/mjsip-sound/src/test/java/test/org/mjsip/sound/TestWavFileReader.java
+++ b/mjsip-sound/src/test/java/test/org/mjsip/sound/TestWavFileReader.java
@@ -1,5 +1,6 @@
 package test.org.mjsip.sound;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
@@ -19,10 +20,10 @@ import org.mjsip.sound.WavFileReader;
 /**
  * Test case for {@link WavFileReader}.
  */
-public class TestWavFileReader {
+class TestWavFileReader {
 	
 	@Test
-	public void testRead() throws IOException, UnsupportedAudioFileException {
+	void testRead() throws IOException, UnsupportedAudioFileException {
 		float sampleRate = 8000;
 		int sampleSizeInBits = 8;
 		int channels = 1;
@@ -44,13 +45,15 @@ public class TestWavFileReader {
 		assertEquals(42, audioInputStream.read());
 	}
 
-	private void assertFormat(AudioFormat expected, AudioInputStream given) {
-		assertEquals(expected.getChannels(), given.getFormat().getChannels());
-		assertEquals(expected.getEncoding(), given.getFormat().getEncoding());
-		assertEquals(expected.getFrameRate(), given.getFormat().getFrameRate());
-		assertEquals(expected.getFrameSize(), given.getFormat().getFrameSize());
-		assertEquals(expected.getSampleRate(), given.getFormat().getSampleRate());
-		assertEquals(expected.getSampleSizeInBits(), given.getFormat().getSampleSizeInBits());
+	private static void assertFormat(AudioFormat expected, AudioInputStream given) {
+		AudioFormat format = given.getFormat();
+		assertAll(() -> assertEquals(expected.getChannels(), format.getChannels()),
+				() -> assertEquals(expected.getEncoding(), format.getEncoding()),
+				() -> assertEquals(expected.getFrameRate(), format.getFrameRate()),
+				() -> assertEquals(expected.getFrameSize(), format.getFrameSize()),
+				() -> assertEquals(expected.getSampleRate(), format.getSampleRate()),
+				() -> assertEquals(expected.getSampleSizeInBits(), format.getSampleSizeInBits())
+		);
 	}
 
 }

--- a/mjsip-ua/src/test/java/org/mjsip/ua/sound/TestAlawSilenceTrimmer.java
+++ b/mjsip-ua/src/test/java/org/mjsip/ua/sound/TestAlawSilenceTrimmer.java
@@ -20,13 +20,13 @@ import org.mjsip.sound.ToneGenerator;
  *
  * @author <a href="mailto:haui@haumacher.de">Bernhard Haumacher</a>
  */
-public class TestAlawSilenceTrimmer {
+class TestAlawSilenceTrimmer {
 
 	/**
 	 * Test loudness analysis with synthetic tones. 
 	 */
 	@Test
-	public void testSinDbLimits() {
+	void testSinDbLimits() {
 		int frequency = 1000;
 		int sampleRate = 16000;
 		
@@ -80,7 +80,7 @@ public class TestAlawSilenceTrimmer {
 	 * Test silence trimming with a real world recording.
 	 */
 	@Test
-	public void testWav() throws IOException, UnsupportedAudioFileException {
+	void testWav() throws IOException, UnsupportedAudioFileException {
 		try (AudioInputStream in = AudioFile.getAudioFileInputStream("./src/test/fixtures/test-alaw.wav")) {
 			AudioFormat format = in.getFormat();
 			try (OutputStream out = AudioFile.getAudioFileOutputStream("./target/test-alaw-trimmed.wav", format)) {

--- a/mjsip-ua/src/test/java/org/mjsip/ua/sound/TestIntRingBuffer.java
+++ b/mjsip-ua/src/test/java/org/mjsip/ua/sound/TestIntRingBuffer.java
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test;
  *
  * @author <a href="mailto:haui@haumacher.de">Bernhard Haumacher</a>
  */
-public class TestIntRingBuffer {
+class TestIntRingBuffer {
 	
 	@Test
-	public void testWrite() {
+	void testWrite() {
 		IntRingBuffer buffer = new IntRingBuffer(3);
 		
 		Assertions.assertTrue(buffer.empty());
@@ -45,7 +45,7 @@ public class TestIntRingBuffer {
 	}
 
 	@Test
-	public void testRandom() {
+	void testRandom() {
 		int limit = 20;
 		IntRingBuffer buffer = new IntRingBuffer(limit);
 		

--- a/mjsip-ua/src/test/java/org/mjsip/ua/sound/TestWavFileSplitter.java
+++ b/mjsip-ua/src/test/java/org/mjsip/ua/sound/TestWavFileSplitter.java
@@ -19,13 +19,13 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for {@link WavFileSplitter}
  */
-public class TestWavFileSplitter {
-	
+class TestWavFileSplitter {
+
 	/**
 	 * Tests splitting a real-world recording.
 	 */
 	@Test
-	public void testSplit() throws IOException, UnsupportedAudioFileException {
+	void testSplit() throws IOException, UnsupportedAudioFileException {
 		File output = new File("./target/TestWavFileSplitter");
 		clear(output);
 		output.mkdirs();

--- a/mjsip-ua/src/test/java/org/mjsip/up/TestPortPool.java
+++ b/mjsip-ua/src/test/java/org/mjsip/up/TestPortPool.java
@@ -12,22 +12,22 @@ import org.mjsip.pool.PortPool.Exhausted;
  * Test case for {@link PortPool}
  */
 @SuppressWarnings("javadoc")
-public class TestPortPool {
+class TestPortPool {
 	
 	@Test
-	public void testSingletonPool() {
+	void testSingletonPool() {
 		PortPool pool = new PortPool(10, 1);
 		
 		Assertions.assertTrue(pool.isAvailable());
 		Assertions.assertEquals(10, pool.allocate());
 		Assertions.assertFalse(pool.isAvailable());
-		assertFailExhausted(pool);
+		Assertions.assertThrows(Exhausted.class, pool::allocate, "Allocating from an exhausted pool must fail.");
 		pool.release(10);
 		Assertions.assertTrue(pool.isAvailable());
 	}
 
 	@Test
-	public void testPool() {
+	void testPool() {
 		PortPool pool = new PortPool(10, 3);
 		
 		Assertions.assertTrue(pool.isAvailable());
@@ -38,15 +38,6 @@ public class TestPortPool {
 		pool.release(10);
 		Assertions.assertEquals(10, pool.allocate());
 		Assertions.assertTrue(pool.isAvailable());
-	}
-
-	private void assertFailExhausted(PortPool pool) {
-		try {
-			pool.allocate();
-			Assertions.fail("Allocating from an exhausted pool must fail.");
-		} catch (Exhausted ex) {
-			// Expected.
-		}
 	}
 	
 }

--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,8 @@
 	
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
-		    <artifactId>junit-jupiter-api</artifactId>
-		    <version>5.10.0</version>
+		    <artifactId>junit-jupiter</artifactId>
+		    <version>5.10.2</version>
 		    <scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
I modernized the junit5 usage:
- I switched from `junit-jupiter-api`  to `junit-jupiter` to get the all junit5 features.
- In junit5 tests and test-classes no longer need to be public, so I removed the public modifier.
- I made use of `@ParameterizedTestthe` in `TestViaHeader` this allows a to run a test multiple times with different arguments (see also [https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests)
- I simplified some assertions 
- I  use `assertAll` in `assertFormat`