### PR TITLE
allow to set _preferIPv4 in config file

### DIFF
--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipConfig.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipConfig.java
@@ -141,7 +141,7 @@ public class SipConfig implements SipOptions {
 	@Option(name = "--via-addr-v6", usage = "Host IPv6 address used in communication with an IPv6 counterpart in the via header.")
 	private String _viaAddr6 = null;
 
-	@Option(name = "--prefer-ipv4", usage = "Whether to use IPv4 addresses by default.")
+	@Option(name = "--prefer-ipv4", handler = YesNoHandler.class, usage = "Whether to use IPv4 addresses by default.")
 	private boolean _preferIPv4 = false;
 
 	@Option(name = "--host-port", usage = "Local SIP port.")


### PR DESCRIPTION
Currently it is not possible to set `preferIPv4` in a config file. Networks where IPv6 is not available need this option to be set. Note that this change means that` --prefer-ipv4` no longer works, only` --prefer-ipv4 yes`