### PR TITLE
Close AudioInputStream to close references to temporary file and to allow for proper deletion

### DIFF
--- a/mjsip-sound/src/main/java/org/mjsip/sound/AudioFile.java
+++ b/mjsip-sound/src/main/java/org/mjsip/sound/AudioFile.java
@@ -128,6 +128,7 @@ public class AudioFile {
 					AudioInputStream audioInputStream = new AudioInputStream(new FileInputStream(tmp), audio_format,
 							tmp.length());
 					AudioSystem.write(audioInputStream, AudioFileFormat.Type.WAVE, new File(file_name));
+					audioInputStream.close();
 
 					tmp.delete();
 		    	}


### PR DESCRIPTION
Closes #15 