### PR TITLE
improve diagnose for invalide environment/command line arguments

### DIFF
--- a/mjsip-util/src/main/java/org/mjsip/config/OptionParser.java
+++ b/mjsip-util/src/main/java/org/mjsip/config/OptionParser.java
@@ -63,6 +63,7 @@ public class OptionParser {
 			}
 
 			CmdLineException problem = null;
+			boolean invalidValueGiven = false;
 			try {
 				// First try, use options form environment and command line. 
 				Collection<String> arguments = new ArrayList<>(envArgs);
@@ -71,13 +72,18 @@ public class OptionParser {
 			} catch (CmdLineException ex) {
 				// Happens, when required configurations are not given on the command line.
 				problem = ex;
+				String message = ex.getMessage();
+				invalidValueGiven = message != null && message.contains(" is not a valid value for ");
+				if (invalidValueGiven) {
+					LOG.warn("{}. Reading from environment/command line aborted", message);
+				}
 			}
 			
 			String argFile = metaConfig.configFile;
 			
 			File file;
 			if (argFile != null && !argFile.isBlank()) {
-				if ("none".equals(argFile.toLowerCase())) {
+				if ("none".equalsIgnoreCase(argFile)) {
 					file = null;
 				} else {
 					file = new File(argFile);
@@ -87,7 +93,7 @@ public class OptionParser {
 					}
 				}
 			} else if (defaultConfigFile != null) {
-				String fileName = System.getProperty("user.home") + "/" + defaultConfigFile;
+				String fileName = System.getProperty("user.home") + File.pathSeparator + defaultConfigFile;
 				file = new File(fileName);
 				if (!file.exists()) {
 					file = null;
@@ -97,7 +103,11 @@ public class OptionParser {
 			}
 			
 			if (file!= null) {
-				LOG.debug("Reading options from: " + file.getAbsolutePath());
+				if (invalidValueGiven) {
+					LOG.warn("Reading options from: {}", file.getAbsolutePath());
+				} else {
+					LOG.debug("Reading options from: {}", file.getAbsolutePath());
+				}
 				
 				ConfigFile configFile = new ConfigFile(file);
 				
@@ -135,7 +145,7 @@ public class OptionParser {
 		String env = optionName.substring(2).replace('-', '_').toUpperCase();
 		String value = System.getenv(env);
 		if (value != null) {
-			LOG.info("Using '" + optionName + "' from environment: " + env + "=" + value);
+			LOG.info("Using '{}' from environment: {}={}", optionName, env, value);
 		}
 		return value;
 	}

--- a/mjsip-util/src/main/java/org/mjsip/config/OptionParser.java
+++ b/mjsip-util/src/main/java/org/mjsip/config/OptionParser.java
@@ -111,9 +111,13 @@ public class OptionParser {
 				
 				ConfigFile configFile = new ConfigFile(file);
 				
-				// Parse all arguments again to check for required arguments not given but give
-				// precedence to arguments given on the command line.
+				// Parse all arguments again to check for required arguments not given and to
+				// allow overwriting configuration file arguments with environment and command
+				// line.
+				// Use the following precedence order: Arguments in the configuration file (lowest),
+				// arguments from the environment, arguments given on the command line (highest).
 				Collection<String> arguments = new ArrayList<>(configFile.toArguments());
+				arguments.addAll(envArgs);
 				arguments.addAll(Arrays.asList(args));
 				
 				parser.parseArgument(arguments);


### PR DESCRIPTION
**Improved error messaging for read interruptions:**
While working on haumacher/phoneblock#97, I noticed that it is currently difficult to identify the cause of interruptions when reading from environment variables or command-line arguments. To address this, I have added a warning to make these issues more transparent.

**Added support for non-Linux systems:**
Additionally, I implemented support for systems that use a different `pathSeparator` than Linux.