### PR TITLE
SipConfig.getViaAddress() seemed to be unuseble

### DIFF
--- a/mjsip-net/src/main/java/org/zoolu/net/AddressType.java
+++ b/mjsip-net/src/main/java/org/zoolu/net/AddressType.java
@@ -4,7 +4,20 @@ package org.zoolu.net;
  * Choice of addresses.
  */
 public enum AddressType {
-	DEFAULT, IP4, IP6;
+	/**
+	 * Select either an IPv4 or IPv6 address depending on the context.
+	 */
+	DEFAULT, 
+	
+	/**
+	 * Use an IPv4 address.
+	 */
+	IP4, 
+	
+	/**
+	 * Use an IPv6 address.
+	 */
+	IP6;
 
 	public static AddressType fromString(String type) {
 		switch (type.toUpperCase()) {

--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipConfig.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipConfig.java
@@ -452,30 +452,8 @@ public class SipConfig implements SipOptions {
 	}
 
 	@Override
-	/**
-	 * Implements {@link SipOptions#getViaAddr()}
-	 * 
-	 * <ul>
-	 * <li>IP4 != null && preferIP4 => IP4</li>
-	 * <li>IP4 != null && IP6 == null => IP4</li>
-	 * <li>IP6 != null && !preferIP4 => IP6</li>
-	 * <li>IP6 != null && IP4 == null => IP6</li>
-	 * <li>else we cal the default method which causes an error</li>
-	 * </ul>
-	 * 
-	 * Unfortunately the behavior of this function is not clearly defined in
-	 * SipOptions Interface.
-	 * 
-	 * @return the vai address according to the rules described above
-	 */
-	public String getViaAddr() {
-		if (_viaAddr4 != null && (_preferIPv4 || _viaAddr6 == null)) {
-			return getViaAddr(AddressType.IP4);
-		} else if (_viaAddr6 != null) {
-			return getViaAddr(AddressType.IP6);
-		} else {
-			return SipOptions.super.getViaAddr();
-		}
+	public boolean getPreferIPv4() {
+		return _preferIPv4;
 	}
 
 	@Override
@@ -486,10 +464,16 @@ public class SipConfig implements SipOptions {
 		case IP6:
 			return getViaAddrIPv6();
 		case DEFAULT:
-			LOG.warn("Using undefined via address type.", new RuntimeException("Stack trace"));
-			break;
+			if (_viaAddr4 != null && (_preferIPv4 || _viaAddr6 == null)) {
+				return _viaAddr4;
+			} else if (_viaAddr6 != null) {
+				return _viaAddr6;
+			} else {
+				// Consistent with the other via address getters.
+				return null;
+			}
 		}
-		return _preferIPv4 ? getViaAddrIPv4() : getViaAddrIPv6();
+		throw new IllegalStateException("No such address type: " + type);
 	}
 
 	@Override

--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipConfig.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipConfig.java
@@ -452,6 +452,33 @@ public class SipConfig implements SipOptions {
 	}
 
 	@Override
+	/**
+	 * Implements {@link SipOptions#getViaAddr()}
+	 * 
+	 * <ul>
+	 * <li>IP4 != null && preferIP4 => IP4</li>
+	 * <li>IP4 != null && IP6 == null => IP4</li>
+	 * <li>IP6 != null && !preferIP4 => IP6</li>
+	 * <li>IP6 != null && IP4 == null => IP6</li>
+	 * <li>else we cal the default method which causes an error</li>
+	 * </ul>
+	 * 
+	 * Unfortunately the behavior of this function is not clearly defined in
+	 * SipOptions Interface.
+	 * 
+	 * @return the vai address according to the rules described above
+	 */
+	public String getViaAddr() {
+		if (_viaAddr4 != null && (_preferIPv4 || _viaAddr6 == null)) {
+			return getViaAddr(AddressType.IP4);
+		} else if (_viaAddr6 != null) {
+			return getViaAddr(AddressType.IP6);
+		} else {
+			return SipOptions.super.getViaAddr();
+		}
+	}
+
+	@Override
 	public String getViaAddr(AddressType type) {
 		switch (type) {
 		case IP4:

--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipOptions.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipOptions.java
@@ -147,27 +147,45 @@ public interface SipOptions {
 	String getUaInfo();
 
 	/**
-	 * Via IP address or fully-qualified domanin name (FQDN).
+	 * Whether to prefer an IPv4 address over an IPv6 address, if both are given but
+	 * no special address type is requested.
+	 * 
+	 * @see AddressType#DEFAULT
+	 */
+	boolean getPreferIPv4();
+
+	/**
+	 * The default via IP address or fully-qualified domain name (FQDN).
 	 * 
 	 * <p>
-	 * Use 'auto-configuration' for auto detection, or let it undefined.
+	 * An address is selected with the following rules:
 	 * </p>
+	 * 
+	 * <ul>
+	 * <li>IP4 != null && preferIP4 => IP4</li>
+	 * <li>IP4 != null && IP6 == null => IP4</li>
+	 * <li>IP6 != null && !preferIP4 => IP6</li>
+	 * <li>IP6 != null && IP4 == null => IP6</li>
+	 * <li>else an error is thrown</li>
+	 * </ul>
+	 * 
+	 * @return The default via address according to the rules described above
+	 * 
+	 * @see #getViaAddrIPv4()
+	 * @see #getViaAddrIPv6()
+	 * @see #getPreferIPv4()
 	 */
 	default String getViaAddr() {
 		return getViaAddr(AddressType.DEFAULT);
 	}
 
 	/**
-	 * Via IP address or fully-qualified domanin name (FQDN).
-	 * 
-	 * <p>
-	 * Use 'auto-configuration' for auto detection, or let it undefined.
-	 * </p>
+	 * Via IP address of the given address type.
 	 */
 	String getViaAddr(AddressType type);
 
 	/**
-	 * Via IPv4 address or fully-qualified domanin name (FQDN).
+	 * Via IPv4 address or fully-qualified domain name (FQDN).
 	 * 
 	 * <p>
 	 * Use 'auto-configuration' for auto detection, or let it undefined.


### PR DESCRIPTION
The function was not implemented here an points to SipOptions.getViaAddress() which always look for an address with AddressType.DEFAULT.

Created an implementation in SipConfig which works in a way. 

Would fix #20