### PR TITLE
Let scheduler be implemented with unlimited parallelism.

### DIFF
--- a/mjsip-sip/src/main/java/org/mjsip/media/RtpStreamSender.java
+++ b/mjsip-sip/src/main/java/org/mjsip/media/RtpStreamSender.java
@@ -411,7 +411,7 @@ public class RtpStreamSender implements Runnable, RtpControlledSender {
 	}
 
 
-	/** Gets the total number of UDP sent octects. */
+	/** Gets the total number of octets sent through the UDP socket. */
 	public long getUdpOctectCounter() {
 		if (rtp_socket!=null) return rtp_socket.getUdpSocket().getSenderOctectCounter();
 		else return 0;

--- a/mjsip-util/src/main/java/org/mjsip/time/ConfiguredScheduler.java
+++ b/mjsip-util/src/main/java/org/mjsip/time/ConfiguredScheduler.java
@@ -4,6 +4,7 @@
 package org.mjsip.time;
 
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 
@@ -33,18 +34,15 @@ public class ConfiguredScheduler implements Scheduler {
 		executor = new ScheduledThreadPoolExecutor(config.getThreadPoolSize(),
 				config.useDaemonThreads() ? new DaemonFactory() : Executors.defaultThreadFactory());
 	}
-
-	/**
-	 * Executor for regular tasks.
-	 */
-	@Override
-	public ScheduledThreadPoolExecutor executor() {
-		return executor;
-	}
 	
 	@Override
 	public void execute(Runnable command) {
 		executor.execute(command);
+	}
+	
+	@Override
+	public ScheduledExecutorService scheduler() {
+		return executor;
 	}
 
 	/**

--- a/mjsip-util/src/main/java/org/mjsip/time/Scheduler.java
+++ b/mjsip-util/src/main/java/org/mjsip/time/Scheduler.java
@@ -4,6 +4,7 @@
 package org.mjsip.time;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -14,9 +15,21 @@ import java.util.concurrent.TimeUnit;
 public interface Scheduler extends Executor {
 
 	/** 
-	 * The {@link ScheduledExecutorService} used for scheduling tasks.
+	 * The executor.
 	 */
-	ScheduledExecutorService executor();
+	default ExecutorService executor() {
+		return scheduler();
+	}
+	
+	/** 
+	 * The scheduler.
+	 */
+	ScheduledExecutorService scheduler();
+
+	@Override
+	default void execute(Runnable command) {
+		executor().execute(command);
+	}
 
 	/**
 	 * Schedules a new task.
@@ -29,31 +42,13 @@ public interface Scheduler extends Executor {
 	 * @return The {@link ScheduledFuture} to control the task.
 	 */
 	default ScheduledFuture<?> schedule(long delay, Runnable task) {
-		return executor().schedule(task, delay, TimeUnit.MILLISECONDS);
+		return scheduler().schedule(task, delay, TimeUnit.MILLISECONDS);
 	}
 
 	/**
 	 * Schedules the given repeated task with a given fixed delay.
 	 */
 	default ScheduledFuture<?> schedulerWithFixedDelay(long delay, Runnable task) {
-		return executor().scheduleWithFixedDelay(task, delay, delay, TimeUnit.MILLISECONDS);
+		return scheduler().scheduleWithFixedDelay(task, delay, delay, TimeUnit.MILLISECONDS);
 	}
-	
-	/**
-	 * Wraps the given {@link ScheduledExecutorService} into a {@link Scheduler}.
-	 */
-	static Scheduler of(ScheduledExecutorService executor) {
-		return new Scheduler() {
-			@Override
-			public ScheduledExecutorService executor() {
-				return executor;
-			}
-
-			@Override
-			public void execute(Runnable command) {
-				executor.execute(command);
-			}
-		};
-	}
-	
 }


### PR DESCRIPTION
A `ScheduledExecutorService` only used core pool size threads for fulfilling execute(...) requests. Many tasks cannot be delayed, only if the core pool size is exhausted, e.g. starting a RTP sender and receiver.