### PR TITLE
Remove tinylog dependency to avoid conflicts with other SLF4J implementations

### DIFF
--- a/mjsip-examples/pom.xml
+++ b/mjsip-examples/pom.xml
@@ -1,19 +1,33 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  
-  <parent>
-    <groupId>org.mjsip</groupId>
-    <artifactId>mjsip-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
-  </parent>
-  
-  <artifactId>mjsip-examples</artifactId>
-  
-  <dependencies>
-    <dependency>
-	    <groupId>org.mjsip</groupId>
-		<artifactId>mjsip-ua</artifactId>
-	</dependency>
-  </dependencies>
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.mjsip</groupId>
+		<artifactId>mjsip-parent</artifactId>
+		<version>2.0.5-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>mjsip-examples</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mjsip</groupId>
+			<artifactId>mjsip-ua</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.tinylog</groupId>
+			<artifactId>slf4j-tinylog</artifactId>
+			<version>2.6.1</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.tinylog</groupId>
+			<artifactId>tinylog-impl</artifactId>
+			<version>2.6.1</version>
+			<scope>runtime</scope>
+		</dependency>
+	</dependencies>
 </project>

--- a/mjsip-net/pom.xml
+++ b/mjsip-net/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.mjsip</groupId>
-    <artifactId>mjsip-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
-  </parent>
-  
-  <artifactId>mjsip-net</artifactId>
-  
-  <dependencies>
-	<dependency>
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
 		<groupId>org.mjsip</groupId>
-		<artifactId>mjsip-util</artifactId>
-	</dependency>
-  </dependencies>
+		<artifactId>mjsip-parent</artifactId>
+		<version>2.0.5-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>mjsip-net</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mjsip</groupId>
+			<artifactId>mjsip-util</artifactId>
+		</dependency>
+	</dependencies>
 </project>

--- a/mjsip-net/pom.xml
+++ b/mjsip-net/pom.xml
@@ -13,7 +13,6 @@
 	<dependency>
 		<groupId>org.mjsip</groupId>
 		<artifactId>mjsip-util</artifactId>
-		<version>2.0.5-SNAPSHOT</version>
 	</dependency>
   </dependencies>
 </project>

--- a/mjsip-phone/pom.xml
+++ b/mjsip-phone/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  
-  <parent>
-    <groupId>org.mjsip</groupId>
-    <artifactId>mjsip-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
-  </parent>
-  
-  <artifactId>mjsip-phone</artifactId>
-  
-  <dependencies>
-    <dependency>
-	    <groupId>org.mjsip</groupId>
-		<artifactId>mjsip-ua</artifactId>
-	</dependency>
-  </dependencies>
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.mjsip</groupId>
+		<artifactId>mjsip-parent</artifactId>
+		<version>2.0.5-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>mjsip-phone</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mjsip</groupId>
+			<artifactId>mjsip-ua</artifactId>
+		</dependency>
+	</dependencies>
 </project>

--- a/mjsip-server/pom.xml
+++ b/mjsip-server/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>org.mjsip</groupId>
     <artifactId>mjsip-parent</artifactId>

--- a/mjsip-server/pom.xml
+++ b/mjsip-server/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.mjsip</groupId>
-    <artifactId>mjsip-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
-  </parent>
-  
-  <artifactId>mjsip-server</artifactId>
-  
-  <dependencies>
-    <dependency>
-	    <groupId>org.mjsip</groupId>
-	    <artifactId>mjsip-sip</artifactId>
-	</dependency>
-  </dependencies>
+	<parent>
+		<groupId>org.mjsip</groupId>
+		<artifactId>mjsip-parent</artifactId>
+		<version>2.0.5-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>mjsip-server</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mjsip</groupId>
+			<artifactId>mjsip-sip</artifactId>
+		</dependency>
+	</dependencies>
 </project>

--- a/mjsip-sip/pom.xml
+++ b/mjsip-sip/pom.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.mjsip</groupId>
-    <artifactId>mjsip-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
-  </parent>
-  
-  <artifactId>mjsip-sip</artifactId>
-  
-  <dependencies>
-	<dependency>
+	<parent>
 		<groupId>org.mjsip</groupId>
-		<artifactId>mjsip-net</artifactId>
-	</dependency>
+		<artifactId>mjsip-parent</artifactId>
+		<version>2.0.5-SNAPSHOT</version>
+	</parent>
 
-	<dependency>
-		<groupId>org.mjsip</groupId>
-		<artifactId>mjsip-sound</artifactId>
-	</dependency>
+	<artifactId>mjsip-sip</artifactId>
 
-	<dependency>
-		<groupId>org.mjsip</groupId>
-		<artifactId>mjsip-util</artifactId>
-	</dependency>
+	<dependencies>
+		<dependency>
+			<groupId>org.mjsip</groupId>
+			<artifactId>mjsip-net</artifactId>
+		</dependency>
 
-	<dependency>
-	    <groupId>args4j</groupId>
-	    <artifactId>args4j</artifactId>
-	</dependency>
-  </dependencies>
+		<dependency>
+			<groupId>org.mjsip</groupId>
+			<artifactId>mjsip-sound</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mjsip</groupId>
+			<artifactId>mjsip-util</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>args4j</groupId>
+			<artifactId>args4j</artifactId>
+		</dependency>
+	</dependencies>
 </project>

--- a/mjsip-sip/pom.xml
+++ b/mjsip-sip/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>org.mjsip</groupId>
     <artifactId>mjsip-parent</artifactId>
@@ -10,23 +11,19 @@
   <artifactId>mjsip-sip</artifactId>
   
   <dependencies>
-
 	<dependency>
 		<groupId>org.mjsip</groupId>
 		<artifactId>mjsip-net</artifactId>
-		<version>2.0.5-SNAPSHOT</version>
 	</dependency>
 
 	<dependency>
 		<groupId>org.mjsip</groupId>
 		<artifactId>mjsip-sound</artifactId>
-		<version>2.0.5-SNAPSHOT</version>
 	</dependency>
 
 	<dependency>
 		<groupId>org.mjsip</groupId>
 		<artifactId>mjsip-util</artifactId>
-		<version>2.0.5-SNAPSHOT</version>
 	</dependency>
 
 	<dependency>

--- a/mjsip-sip/pom.xml
+++ b/mjsip-sip/pom.xml
@@ -29,7 +29,6 @@
 	<dependency>
 	    <groupId>args4j</groupId>
 	    <artifactId>args4j</artifactId>
-	    <version>2.37</version>
-	</dependency>	
+	</dependency>
   </dependencies>
 </project>

--- a/mjsip-sound/pom.xml
+++ b/mjsip-sound/pom.xml
@@ -13,7 +13,6 @@
 	<dependency>
 		<groupId>org.mjsip</groupId>
 		<artifactId>mjsip-util</artifactId>
-		<version>2.0.5-SNAPSHOT</version>
 	</dependency>
   </dependencies>
 </project>

--- a/mjsip-sound/pom.xml
+++ b/mjsip-sound/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.mjsip</groupId>
-    <artifactId>mjsip-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
-  </parent>
-  
-  <artifactId>mjsip-sound</artifactId>
-  
-  <dependencies>
-	<dependency>
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
 		<groupId>org.mjsip</groupId>
-		<artifactId>mjsip-util</artifactId>
-	</dependency>
-  </dependencies>
+		<artifactId>mjsip-parent</artifactId>
+		<version>2.0.5-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>mjsip-sound</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mjsip</groupId>
+			<artifactId>mjsip-util</artifactId>
+		</dependency>
+	</dependencies>
 </project>

--- a/mjsip-ua/pom.xml
+++ b/mjsip-ua/pom.xml
@@ -1,23 +1,24 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.mjsip</groupId>
-    <artifactId>mjsip-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
-  </parent>
-  
-  <artifactId>mjsip-ua</artifactId>
-  
-  <dependencies>
-    <dependency>
-	    <groupId>org.mjsip</groupId>
-	    <artifactId>mjsip-sip</artifactId>
-	</dependency>
+	<modelVersion>4.0.0</modelVersion>
 
-	<dependency>
-	    <groupId>args4j</groupId>
-	    <artifactId>args4j</artifactId>
-	</dependency>
-  </dependencies>
+	<parent>
+		<groupId>org.mjsip</groupId>
+		<artifactId>mjsip-parent</artifactId>
+		<version>2.0.5-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>mjsip-ua</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mjsip</groupId>
+			<artifactId>mjsip-sip</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>args4j</groupId>
+			<artifactId>args4j</artifactId>
+		</dependency>
+	</dependencies>
 </project>

--- a/mjsip-ua/pom.xml
+++ b/mjsip-ua/pom.xml
@@ -18,7 +18,6 @@
 	<dependency>
 	    <groupId>args4j</groupId>
 	    <artifactId>args4j</artifactId>
-	    <version>2.37</version>
-	</dependency>	
+	</dependency>
   </dependencies>
 </project>

--- a/mjsip-util/pom.xml
+++ b/mjsip-util/pom.xml
@@ -13,7 +13,6 @@
 	<dependency>
 	    <groupId>args4j</groupId>
 	    <artifactId>args4j</artifactId>
-	    <version>2.37</version>
-	</dependency>	
+	</dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,12 @@
 				<artifactId>mjsip-sound</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+
+			<dependency>
+				<groupId>args4j</groupId>
+				<artifactId>args4j</artifactId>
+				<version>2.37</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,15 +12,15 @@
 	<url>http://www.mjsip.org</url>
 	<description>
 		A complete java-based implementation of a SIP stack.
-		
-		SIP (Session Initiation Protocol) is the IETF (Internet Engineering Task Force) signaling standard for managing 
+
+		SIP (Session Initiation Protocol) is the IETF (Internet Engineering Task Force) signaling standard for managing
 		multimedia session initiation; it is currently defined in RFC 3261. SIP can be used to initiate voice, video and
-		multimedia sessions, for both interactive applications (e.g. an IP phone call or a video conference) and not 
-		interactive ones (e.g. a Video Streaming), and it is the more promising candidate as call setup signaling for 
-		the present day and future IP based telephony services. SIP has been also proposed for session initiation 
+		multimedia sessions, for both interactive applications (e.g. an IP phone call or a video conference) and not
+		interactive ones (e.g. a Video Streaming), and it is the more promising candidate as call setup signaling for
+		the present day and future IP based telephony services. SIP has been also proposed for session initiation
 		related uses, such as for messaging, gaming, etc.
 
-		The mjSIP stack has been used in research activities by Dept. of Engineering and Architecture at University of 
+		The mjSIP stack has been used in research activities by Dept. of Engineering and Architecture at University of
 		Parma and by DIE - University of Roma "Tor Vergata" and several commercial products.
 	</description>
 
@@ -87,27 +87,13 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.tinylog</groupId>
-			<artifactId>slf4j-tinylog</artifactId>
-			<version>2.6.1</version>
-		    <scope>runtime</scope>
-		</dependency>
-		
-		<dependency>
-		    <groupId>org.tinylog</groupId>
-		    <artifactId>tinylog-impl</artifactId>
-		    <version>2.6.1</version>
-		    <scope>runtime</scope>
-		</dependency>
-	
-		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
 		    <artifactId>junit-jupiter</artifactId>
 		    <version>5.10.2</version>
 		    <scope>test</scope>
 		</dependency>
 	</dependencies>
-	
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -146,7 +132,7 @@
 				<targetPath>META-INF</targetPath>
 			</resource>
 		</resources>
-		
+
 		<plugins>
 			<plugin>
 			    <groupId>org.apache.maven.plugins</groupId>
@@ -222,7 +208,7 @@
 				    <artifactId>maven-resources-plugin</artifactId>
 				    <version>3.3.0</version>
 				</plugin>
-	
+
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
@@ -236,6 +222,6 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-		
+
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,16 +81,16 @@
 
 	<dependencies>
 		<dependency>
-		    <groupId>org.slf4j</groupId>
-		    <artifactId>slf4j-api</artifactId>
-		    <version>2.0.7</version>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.7</version>
 		</dependency>
 
 		<dependency>
-		    <groupId>org.junit.jupiter</groupId>
-		    <artifactId>junit-jupiter</artifactId>
-		    <version>5.10.2</version>
-		    <scope>test</scope>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.10.2</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
@@ -159,8 +159,8 @@
 
 		<plugins>
 			<plugin>
-			    <groupId>org.apache.maven.plugins</groupId>
-			    <artifactId>maven-resources-plugin</artifactId>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
 			</plugin>
 
 			<plugin>
@@ -228,9 +228,9 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-				    <groupId>org.apache.maven.plugins</groupId>
-				    <artifactId>maven-resources-plugin</artifactId>
-				    <version>3.3.0</version>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>3.3.0</version>
 				</plugin>
 
 				<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,24 @@
 				<artifactId>mjsip-ua</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+
+			<dependency>
+				<groupId>org.mjsip</groupId>
+				<artifactId>mjsip-util</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.mjsip</groupId>
+				<artifactId>mjsip-net</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.mjsip</groupId>
+				<artifactId>mjsip-sound</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
This PR removes the SLF4J implementation (`slf4j-tinylog` and `tinylog-impl`) from the project dependencies.  
Libraries should only depend on `slf4j-api` and not include a specific logging implementation to allow applications to choose their preferred logging backend.

Including an SLF4J implementation in a library can cause binding conflicts when the application already provides a different implementation (e.g., Logback, Log4j2).  
Following [SLF4J best practices](https://www.slf4j.org/manual.html#libraries), libraries should only depend on `slf4j-api` and let the application manage the logging configuration.
This change improves compatibility and reduces the risk of classpath issues for users of the library.

To not break the logging in the examples, I added `slf4j-tinylog` and `tinylog-impl` directly to the `mjsip-examples` module. This module should not be a dependency of an application, so there should be no issues with binding conflicts or classpath issues.

I also took the liberty of making the following additional changes:
* Added the modules `mjsip-util`, `mjsip-net` and `mjsip-sound` to the parent's dependency management. This allows other modules that depend on them to omit explicit version declarations.
* Moved the version declaration of `args4j` to the parent’s dependency management, making it easier to manage.
* Unified the formatting of all `pom.xml` files. They now consistently use tabs for indentation instead of a mix of tabs and spaces.

Please let me know if you would prefer these changes to be split into separate PRs or if I should remove them entirely.