### PR TITLE
Reject SIP messages with an implausible Content-Length

### DIFF
--- a/mjsip-net/src/main/java/org/zoolu/net/UdpProvider.java
+++ b/mjsip-net/src/main/java/org/zoolu/net/UdpProvider.java
@@ -27,6 +27,8 @@ package org.zoolu.net;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 
+import org.slf4j.LoggerFactory;
+
 
 /** UdpProvider provides an UDP send/receive service.
   * On the receiver side it waits for UDP datagrams and passes them
@@ -39,7 +41,9 @@ import java.io.InterruptedIOException;
   * receiving packets.
   */
 public class UdpProvider extends Thread {
-	
+
+	private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(UdpProvider.class);
+
 	/** The reading buffer size */
 	public static final int BUFFER_SIZE=65535;
 	  
@@ -179,15 +183,19 @@ public class UdpProvider extends Thread {
 					continue;
 				}
 				if (packet.getLength()>=minimum_length) {
-					//if (listener!=null) listener.onReceivedPacket(this,packet);
-					if (listener!=null) try {  listener.onReceivedPacket(this,packet);  } catch (Exception e) {}
+					// Note: A failure while processing a single packet must not terminate the receiver
+					// thread, since that would stop the service for all peers. Errors are caught as
+					// well, since e.g. an OutOfMemoryError may be provoked by a malicious packet.
+					if (listener!=null) try {  listener.onReceivedPacket(this,packet);  } catch (Throwable t) {
+						LOG.warn("Dropping packet from {}:{} that could not be processed.",packet.getIpAddress(),Integer.valueOf(packet.getPort()),t);
+					}
 					if (alive_time>0) expire=System.currentTimeMillis()+alive_time;
 				}
 				packet=new UdpPacket(buf, buf.length);
 			}
 		}
-		catch (Exception e) {
-			error=e;
+		catch (Throwable t) {
+			error=(t instanceof Exception)? (Exception)t : new RuntimeException(t);
 			stop=true;
 		} 
 		is_running=false;

--- a/mjsip-net/src/test/java/test/org/zoolu/net/TestUdpProvider.java
+++ b/mjsip-net/src/test/java/test/org/zoolu/net/TestUdpProvider.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package test.org.zoolu.net;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.zoolu.net.IpAddress;
+import org.zoolu.net.UdpPacket;
+import org.zoolu.net.UdpProvider;
+import org.zoolu.net.UdpProviderListener;
+import org.zoolu.net.UdpSocket;
+
+/**
+ * Test for the robustness of the {@link UdpProvider} receiver thread.
+ */
+class TestUdpProvider {
+
+	/** Maximum time to wait for the packets to be delivered. */
+	private static final int TIMEOUT_MS=5000;
+
+	/**
+	 * A packet that cannot be processed must not terminate the receiver thread, since that would stop
+	 * the service for all peers. This especially holds for an {@link Error} such as the
+	 * {@link OutOfMemoryError} that a packet announcing a huge content length used to provoke.
+	 */
+	@Test
+	void testReceiverSurvivesFailureWhileProcessingPacket() throws IOException, InterruptedException {
+		List<String> packets=Arrays.asList("error: huge content length","exception: some other problem","regular packet");
+
+		CountDownLatch received=new CountDownLatch(packets.size());
+		List<String> processed=new ArrayList<>();
+
+		UdpProviderListener listener=new UdpProviderListener() {
+			@Override
+			public void onReceivedPacket(UdpProvider udp, UdpPacket packet) {
+				String data=new String(packet.getData(),packet.getOffset(),packet.getLength(),StandardCharsets.UTF_8);
+				try {
+					if (data.startsWith("error")) throw new OutOfMemoryError("Simulated failure processing '"+data+"'.");
+					if (data.startsWith("exception")) throw new IllegalStateException("Simulated failure processing '"+data+"'.");
+					synchronized (processed) {
+						processed.add(data);
+					}
+				}
+				finally {
+					received.countDown();
+				}
+			}
+
+			@Override
+			public void onServiceTerminated(UdpProvider udp, Exception error) {
+				// Ignore.
+			}
+		};
+
+		IpAddress localhost=new IpAddress(InetAddress.getLoopbackAddress());
+		try (UdpSocket receiver=new UdpSocket(0,localhost); UdpSocket sender=new UdpSocket(0,localhost)) {
+			UdpProvider provider=new UdpProvider(receiver,listener);
+			try {
+				for (String data : packets) {
+					byte[] buf=data.getBytes(StandardCharsets.UTF_8);
+					sender.send(new UdpPacket(buf,buf.length,localhost,receiver.getLocalPort()));
+				}
+
+				assertTrue(received.await(TIMEOUT_MS,TimeUnit.MILLISECONDS),"Not all packets have been received.");
+				assertTrue(provider.isRunning(),"The receiver thread has been terminated by a failing packet.");
+				synchronized (processed) {
+					assertEquals(Collections.singletonList("regular packet"),processed);
+				}
+			}
+			finally {
+				provider.halt();
+			}
+		}
+	}
+
+}

--- a/mjsip-sip/src/main/java/org/mjsip/sip/message/BasicSipMessage.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/message/BasicSipMessage.java
@@ -194,6 +194,8 @@ public abstract class BasicSipMessage {
 			ContentLengthHeader clh=getContentLengthHeader();
 			if (clh!=null) {
 				int body_len=clh.getContentLength();
+				int available=str.length()-par.getPos();
+				checkBodyLength(body_len,available);
 				body=par.getString(body_len).getBytes();
 			}
 			else
@@ -201,11 +203,14 @@ public abstract class BasicSipMessage {
 				String body_str=par.getRemainingString();
 				body=(body_str.length()>0)? body_str.getBytes() : null;
 			}
-			
+
 			return par.getPos();
 		}
+		catch (MalformedSipMessageException e) {
+			throw e;
+		}
 		catch (Exception e) {
-			throw new MalformedSipMessageException(e.getMessage()); 
+			throw new MalformedSipMessageException(e.getMessage());
 		}
 	}
 
@@ -213,12 +218,44 @@ public abstract class BasicSipMessage {
 	/** Sets the message from an array of bytes containing the SIP message.
 	  * The array of bytes must contain a valid SIP message, otherwise a MalformedSipMessageException is thrown.
 	  * Possible additional bytes after the end of the SIP message are simply ignored.
-	  * @param buf the byte array containing the SIP message 
+	  * <p>
+	  * The given bytes are interpreted as a single transport packet of a datagram-oriented transport,
+	  * see {@link #setMessage(byte[],int,int,boolean)}.
+	  * </p>
+	  * @param buf the byte array containing the SIP message
 	  * @param off the offset within the byte array
 	  * @param len the number of available bytes
 	  * @return the number of used bytes
 	  * @exception MalformedSipMessageException in case the array of bytes does not contain (starting at the given offset with) a valid SIP message */
 	protected int setMessage(byte[] buf, int off, int len) throws MalformedSipMessageException {
+		return setMessage(buf,off,len,false);
+	}
+
+
+	/** Sets the message from an array of bytes containing the SIP message.
+	  * The array of bytes must contain a valid SIP message, otherwise a MalformedSipMessageException is thrown.
+	  * Possible additional bytes after the end of the SIP message are simply ignored.
+	  * <p>
+	  * How the end of the message body is determined depends on the transport the bytes have been
+	  * received from (see RFC 3261, 18.3). In a datagram-oriented transport (<code>stream</code> is
+	  * <code>false</code>), the given bytes are a single transport packet: A message body without a
+	  * Content-Length header field ends at the end of the packet. In a stream-oriented transport
+	  * (<code>stream</code> is <code>true</code>), the given bytes may contain more than one message,
+	  * so a Content-Length header field is the only way to tell where the message ends: A message
+	  * without that header field is rejected instead of consuming bytes that potentially belong to a
+	  * subsequent message. Moreover, a message that is not completely contained in the given bytes is
+	  * only an error in a datagram-oriented transport, while in a stream-oriented transport the rest
+	  * of the message may still arrive, which is reported by an {@link IncompleteSipMessageException}.
+	  * </p>
+	  * @param buf the byte array containing the SIP message
+	  * @param off the offset within the byte array
+	  * @param len the number of available bytes
+	  * @param stream whether the bytes have been received from a stream-oriented transport
+	  * @return the number of used bytes
+	  * @exception IncompleteSipMessageException in case of a stream-oriented transport, if the message
+	  *            is not completely contained in the given bytes
+	  * @exception MalformedSipMessageException in case the array of bytes does not contain (starting at the given offset with) a valid SIP message */
+	protected int setMessage(byte[] buf, int off, int len, boolean stream) throws MalformedSipMessageException {
 		try {
 			// skip any leading CRLF
 			/*int skip_len=0;
@@ -227,25 +264,22 @@ public abstract class BasicSipMessage {
 				len--;
 				skip_len++;
 			}*/
-		
+
 			// find total header length
-			byte[] delim={(byte)'\r',(byte)'\n',(byte)'\r',(byte)'\n'};
-			int siph_len=ByteUtils.indexOf(delim,buf,off,len);
+			int siph_len=headerLength(buf,off,len);
 			if (siph_len<0) {
-				delim=new byte[]{(byte)'\n',(byte)'\n'};
-				siph_len=ByteUtils.indexOf(delim,buf,off,len);
+				if (stream) throw new IncompleteSipMessageException("Incomplete message header: No SIP header delimiter found within "+len+" bytes.");
+				throw new MalformedSipMessageException("No SIP header delimiter found.");
 			}
-			if (siph_len<0) throw new MalformedSipMessageException("No SIP header delimiter found.");
 			// else
-			siph_len+=delim.length;
 			String siph_str=new String(buf,off,siph_len);
-	
+
 			// parse first line
 			SipParser par=new SipParser(siph_str);
-			String proto_version=siph_str.substring(0,SIP_VERSION.length());     
+			String proto_version=siph_str.substring(0,SIP_VERSION.length());
 			if (proto_version.equalsIgnoreCase(SIP_VERSION)) status_line=par.getStatusLine();
 			else request_line=par.getRequestLine();
-	
+
 			// parse all header fields
 			//headers=new Vector();
 			if (headers.size()>0) headers.removeAllElements();
@@ -254,19 +288,71 @@ public abstract class BasicSipMessage {
 				headers.addElement(h);
 				h=par.getHeader();
 			}
-	
+
 			// get body
 			int body_len=0;
+			int available=len-siph_len;
 			ContentLengthHeader clh=getContentLengthHeader();
-			if (clh!=null) body_len=clh.getContentLength();
-			else if (getContentTypeHeader()!=null) body_len=len-siph_len;
+			if (clh!=null) {
+				body_len=clh.getContentLength();
+				if (stream && body_len>=0 && body_len>available)
+					throw new IncompleteSipMessageException("Incomplete message body: Only "+available+" of "+body_len+" bytes received.");
+				checkBodyLength(body_len,available);
+			}
+			else if (stream) {
+				// Without a Content-Length header field, the end of the message cannot be determined,
+				// since the remaining bytes may belong to a subsequent message.
+				throw new MalformedSipMessageException("Missing Content-Length header field in a message received over a stream-oriented transport.");
+			}
+			else if (getContentTypeHeader()!=null) body_len=available;
 			body=(body_len>0)? ByteUtils.copy(buf,off+siph_len,body_len) : null;
-			
+
 			return /*skip_len+*/siph_len+body_len;
 		}
-		catch (Exception e) {
-			throw new MalformedSipMessageException(e.getMessage()); 
+		catch (MalformedSipMessageException e) {
+			throw e;
 		}
+		catch (Exception e) {
+			throw new MalformedSipMessageException(e.getMessage());
+		}
+	}
+
+
+	/** The alternative sequences terminating the header of a SIP message. */
+	private static final byte[][] HEADER_DELIMITERS={
+		{(byte)'\r',(byte)'\n',(byte)'\r',(byte)'\n'},
+		{(byte)'\n',(byte)'\n'}
+	};
+
+	/** Finds the end of the message header.
+	  * @param buf the byte array containing the SIP message
+	  * @param off the offset within the byte array
+	  * @param len the number of available bytes
+	  * @return the length of the message header including the terminating empty line, or -1 if the
+	  *         given bytes do not contain a complete message header */
+	private static int headerLength(byte[] buf, int off, int len) {
+		int result=-1;
+		int found=len;
+		for (byte[] delim : HEADER_DELIMITERS) {
+			int index=ByteUtils.indexOf(delim,buf,off,len);
+			// Note: The delimiter occurring first terminates the header. A later one must not be
+			// taken, since it may already belong to a subsequent message in a stream of messages.
+			if (index>=0 && index<found) {
+				found=index;
+				result=index+delim.length;
+			}
+		}
+		return result;
+	}
+
+	/** Checks that a Content-Length header field value describes a body that is actually there.
+	  * @param body_len the declared length of the message body
+	  * @param available the number of bytes available after the message header
+	  * @exception MalformedSipMessageException if the declared length is negative, or if the declared
+	  *            body is not completely contained in the received message */
+	private static void checkBodyLength(int body_len, int available) throws MalformedSipMessageException {
+		if (body_len<0) throw new MalformedSipMessageException("Negative Content-Length: "+body_len);
+		if (body_len>available) throw new MalformedSipMessageException("Truncated message body: Content-Length of "+body_len+" exceeds the "+available+" bytes received.");
 	}
 
 

--- a/mjsip-sip/src/main/java/org/mjsip/sip/message/IncompleteSipMessageException.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/message/IncompleteSipMessageException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package org.mjsip.sip.message;
+
+/**
+ * Signals that a message could not be parsed because it has not been completely received yet.
+ *
+ * <p>
+ * In contrast to a plain {@link MalformedSipMessageException}, this exception is recoverable: When
+ * more data of a stream-oriented transport becomes available, parsing the message can be retried.
+ * Only messages received over a stream-oriented transport can be incomplete, since a message
+ * received over a datagram-oriented transport is either contained in a single transport packet, or
+ * malformed (see RFC 3261, 18.3).
+ * </p>
+ */
+public class IncompleteSipMessageException extends MalformedSipMessageException {
+
+	/**
+	 * Creates a {@link IncompleteSipMessageException}.
+	 *
+	 * @param error
+	 *        the error message
+	 */
+	public IncompleteSipMessageException(String error) {
+		super(error);
+	}
+
+}

--- a/mjsip-sip/src/main/java/org/mjsip/sip/message/SipMessage.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/message/SipMessage.java
@@ -94,9 +94,26 @@ public class SipMessage extends BasicSipMessage {
 		super(str);
 	}
 
-	/** Creates a new Message */
+	/** Creates a new Message.
+	  * <p>
+	  * Note: A parser error is only logged, which produces a partially initialized message. Use
+	  * {@link #parse(byte[],int,int)} for messages received from the network.
+	  * </p> */
 	public SipMessage(byte[] buff, int offset, int len) {
 		super(buff,offset,len);
+	}
+
+	/** Parses a message received from a datagram-oriented transport.
+	  * @param buf the byte array containing the message
+	  * @param off the message offset within the byte array
+	  * @param len the message len
+	  * @return the parsed message
+	  * @exception MalformedSipMessageException if the given bytes do not contain (starting at the given
+	  *            offset with) a valid SIP message */
+	public static SipMessage parse(byte[] buf, int off, int len) throws MalformedSipMessageException {
+		SipMessage result=new SipMessage();
+		result.setMessage(buf,off,len);
+		return result;
 	}
 
 	/** Creates a new Message */

--- a/mjsip-sip/src/main/java/org/mjsip/sip/message/SipMessageBuffer.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/message/SipMessageBuffer.java
@@ -26,22 +26,41 @@ package org.mjsip.sip.message;
 /** Class SipMessageBuffer provides methods for extracting SIP messages from a byte buffer.
   */
 public class SipMessageBuffer {
-	
+
+	/** Default value for the maximum size of a single SIP message (in bytes). */
+	public static final int DEFAULT_MAX_MESSAGE_SIZE=1024*1024;
 
 	/** Buffer */
 	byte[] buffer=null;
-	
+
 	/** Current data offset within the buffer */
 	int offset=0;
-	
+
 	/** Current data length */
 	//int length=0;
 
-	
-	
-	/** Creates a new SipMessageBuffer. */
+	/** Maximum size of a single SIP message (in bytes) */
+	private final int max_message_size;
+
+
+
+	/** Creates a new SipMessageBuffer accepting messages of {@link #DEFAULT_MAX_MESSAGE_SIZE} bytes. */
 	public SipMessageBuffer() {
-		
+		this(DEFAULT_MAX_MESSAGE_SIZE);
+	}
+
+	/** Creates a new SipMessageBuffer.
+	  * @param max_message_size the maximum size of a single SIP message (in bytes); data exceeding
+	  *        that size without forming a complete message is rejected, since it can neither be
+	  *        parsed nor be buffered indefinitely */
+	public SipMessageBuffer(int max_message_size) {
+		this.max_message_size=max_message_size;
+	}
+
+	/** Gets the maximum size of a single SIP message (in bytes).
+	  * @return the maximum message size */
+	public int getMaxMessageSize() {
+		return max_message_size;
 	}
 
 	/** Gets the current buffer.
@@ -104,10 +123,32 @@ public class SipMessageBuffer {
 	}
 
 	/** Tries to get a new SIP message from the buffer.
-	  * @return a new SIP message or null */
+	  * <p>
+	  * The buffer is a stream of messages, therefore only a message with a Content-Length header field
+	  * can be framed, see {@link BasicSipMessage#setMessage(byte[],int,int,boolean)}. As long as the buffer
+	  * does not contain a complete message, an {@link IncompleteSipMessageException} is thrown and the
+	  * buffer contents are kept for a later retry. Any other {@link MalformedSipMessageException} means
+	  * that the start of the next message within the stream cannot be determined any more.
+	  * </p>
+	  * @return a new SIP message or null
+	  * @exception IncompleteSipMessageException if the buffer does not (yet) contain a complete message
+	  * @exception MalformedSipMessageException if the buffer does not start with a valid SIP message, or
+	  *            if the buffered data exceeds {@link #getMaxMessageSize()} without forming a message */
 	public synchronized SipMessage parseSipMessage() throws MalformedSipMessageException {
+		int length=getLength();
+		if (length<=0) throw new IncompleteSipMessageException("No data buffered.");
 		SipMessage msg=new SipMessage();
-		offset+=msg.setMessage(buffer,offset,buffer.length-offset);
+		try {
+			offset+=msg.setMessage(buffer,offset,length,true);
+		}
+		catch (IncompleteSipMessageException ex) {
+			// Note: An incomplete message must be kept until the rest of it arrives. Without a limit,
+			// a peer could exhaust the memory by announcing a huge Content-Length or by never
+			// terminating the message header.
+			if (length>max_message_size)
+				throw new MalformedSipMessageException("Message too large: More than "+max_message_size+" bytes received without a complete message.");
+			throw ex;
+		}
 		// DEBUG:
 		/*try {
 			offset+=msg.setMessage(buffer,offset,buffer.length-offset);

--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipConfig.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipConfig.java
@@ -27,6 +27,7 @@ import org.mjsip.config.YesNoHandler;
 import org.mjsip.sip.address.SipURI;
 import org.mjsip.sip.config.IpAddressHandler;
 import org.mjsip.sip.config.SipURIHandler;
+import org.mjsip.sip.message.SipMessageBuffer;
 import org.mjsip.sip.message.SipMethods;
 import org.slf4j.LoggerFactory;
 import org.zoolu.net.AddressType;
@@ -157,6 +158,9 @@ public class SipConfig implements SipOptions {
 
 	@Option(name = "--max-connections")
 	private int _maxConnections = 0;
+
+	@Option(name = "--max-message-size", usage = "Maximum size of a single SIP message received over a stream-oriented transport.")
+	private int _maxMessageSize = SipMessageBuffer.DEFAULT_MAX_MESSAGE_SIZE;
 
 	@Option(name = "--outbound-proxy", handler = SipURIHandler.class, usage = "Use the given outbound proxy.")
 	private SipURI _outboundProxy = null;
@@ -540,6 +544,16 @@ public class SipConfig implements SipOptions {
 
 	public void setMaxConnections(int maxConnections) {
 		this._maxConnections = maxConnections;
+	}
+
+	@Override
+	public int getMaxMessageSize() {
+		return _maxMessageSize;
+	}
+
+	/** @see #getMaxMessageSize() */
+	public void setMaxMessageSize(int maxMessageSize) {
+		this._maxMessageSize = maxMessageSize;
 	}
 
 	@Override

--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipOptions.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipOptions.java
@@ -4,6 +4,7 @@
 package org.mjsip.sip.provider;
 
 import org.mjsip.sip.address.SipURI;
+import org.mjsip.sip.message.SipMessageBuffer;
 import org.zoolu.net.AddressType;
 import org.zoolu.net.IpAddress;
 
@@ -42,6 +43,14 @@ public interface SipOptions {
 
 	/** Max number of (contemporary) open connections */
 	int getMaxConnections();
+
+	/**
+	 * Maximum size of a single SIP message (in bytes) received over a stream-oriented transport. A
+	 * connection delivering more data than that without forming a complete message is closed.
+	 */
+	default int getMaxMessageSize() {
+		return SipMessageBuffer.DEFAULT_MAX_MESSAGE_SIZE;
+	}
 
 	/**
 	 * Outbound proxy URI ([sip:]host_addr[:host_port][;transport=proto]). Use 'NONE' for not using

--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipProvider.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipProvider.java
@@ -260,6 +260,9 @@ public class SipProvider implements SipTransportListener {
 				}
 				
 				if (transp!=null)  {
+					if (transp instanceof SipTransportCO) {
+						((SipTransportCO)transp).setMaxMessageSize(_sipConfig.getMaxMessageSize());
+					}
 					setTransport(transp);
 				}
 			}

--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipTransportCO.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/SipTransportCO.java
@@ -31,6 +31,7 @@ import java.util.Hashtable;
 import java.util.Map;
 
 import org.mjsip.sip.message.SipMessage;
+import org.mjsip.sip.message.SipMessageBuffer;
 import org.slf4j.LoggerFactory;
 import org.zoolu.net.IpAddress;
 import org.zoolu.net.SocketAddress;
@@ -59,7 +60,10 @@ public abstract class SipTransportCO implements SipTransport/*, SipTransportConn
 	boolean manual=false;
 
 	/** Whether changing the Via protocol, sent-by, and port values of sending messages according to the transport connection */
-	boolean force_sent_by=false;   
+	boolean force_sent_by=false;
+
+	/** Maximum size of a single received SIP message (in bytes) */
+	int max_message_size=SipMessageBuffer.DEFAULT_MAX_MESSAGE_SIZE;
 
 
 
@@ -98,9 +102,29 @@ public abstract class SipTransportCO implements SipTransport/*, SipTransportConn
 
 	/** Whether the "force-sent-by" mode is set.
 	  * See method {@link #setForceSentBy(boolean)} for more details.
-	  * @return true if "force-sent-by" mode is set */ 
+	  * @return true if "force-sent-by" mode is set */
 	public boolean isForceSentBySet() {
 		return force_sent_by;
+	}
+
+
+	/** Sets the maximum size of a single received SIP message.
+	  * A connection delivering more data than that without forming a complete message is closed, since
+	  * such data can neither be parsed nor be buffered indefinitely.
+	  * <p>
+	  * The setting is applied to connections established afterwards.
+	  * </p>
+	  * @param max_message_size the maximum size of a single received SIP message (in bytes) */
+	public void setMaxMessageSize(int max_message_size) {
+		this.max_message_size=max_message_size;
+	}
+
+
+	/** Gets the maximum size of a single received SIP message.
+	  * See method {@link #setMaxMessageSize(int)} for more details.
+	  * @return the maximum size of a single received SIP message (in bytes) */
+	public int getMaxMessageSize() {
+		return max_message_size;
 	}
 
 

--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/TcpTransport.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/TcpTransport.java
@@ -113,7 +113,7 @@ public class TcpTransport extends SipTransportCO/* implements TcpServerListener*
 		LOG.debug("incoming connection from {}:{}", socket.getAddress(), socket.getPort());
 		if (tcp_server==this.tcp_server) {
 			try {
-				SipTransportConnection conn = new TcpTransportConnection(socket, this_conn_listener);
+				SipTransportConnection conn = new TcpTransportConnection(socket, getMaxMessageSize(), this_conn_listener);
 				LOG.debug("tcp connection {} opened", conn);
 				addConnection(conn);
 				if (listener != null)
@@ -136,7 +136,7 @@ public class TcpTransport extends SipTransportCO/* implements TcpServerListener*
 	@Override
 	protected SipTransportConnection createTransportConnection(SocketAddress remote_soaddr) throws IOException {
 		TcpSocket tcp_socket=new TcpSocket(remote_soaddr.getAddress(),remote_soaddr.getPort());
-		return new TcpTransportConnection(tcp_socket,this_conn_listener);
+		return new TcpTransportConnection(tcp_socket,getMaxMessageSize(),this_conn_listener);
 	}
 
 

--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/TcpTransportConnection.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/TcpTransportConnection.java
@@ -27,6 +27,7 @@ package org.mjsip.sip.provider;
 
 import java.io.IOException;
 
+import org.mjsip.sip.message.IncompleteSipMessageException;
 import org.mjsip.sip.message.SipMessage;
 import org.mjsip.sip.message.SipMessageBuffer;
 import org.slf4j.LoggerFactory;
@@ -56,42 +57,61 @@ public class TcpTransportConnection implements SipTransportConnection/*, TcpConn
 	long last_time;
 	
 	/** Receiver buffer. */
-	SipMessageBuffer buffer=new SipMessageBuffer();
-	  
+	SipMessageBuffer buffer;
+
 	/** SipTransportConnection listener */
 	SipTransportConnectionListener listener;   
 
 
 
-	/** Creates a new TcpTransportConnection. */ 
+	/** Creates a new TcpTransportConnection. */
 	public TcpTransportConnection(IpAddress remote_ipaddr, int remote_port, SipTransportConnectionListener listener) throws IOException {
-		init(new TcpSocket(remote_ipaddr,remote_port),listener);
+		this(new TcpSocket(remote_ipaddr,remote_port),listener);
 	}
 
 
 	/**
-	 * Creates a new TcpTransportConnection.
-	 * 
+	 * Creates a new TcpTransportConnection accepting messages of
+	 * {@link SipMessageBuffer#DEFAULT_MAX_MESSAGE_SIZE} bytes.
+	 *
 	 * @param socket
 	 *        the TCP socket
 	 * @param listener
 	 *        the TcpTransportConnection listener
 	 */
 	public TcpTransportConnection(TcpSocket socket, SipTransportConnectionListener listener) throws IOException {
-		init(socket,listener);
+		this(socket,SipMessageBuffer.DEFAULT_MAX_MESSAGE_SIZE,listener);
+	}
+
+
+	/**
+	 * Creates a new TcpTransportConnection.
+	 *
+	 * @param socket
+	 *        the TCP socket
+	 * @param max_message_size
+	 *        the maximum size of a single received SIP message (in bytes)
+	 * @param listener
+	 *        the TcpTransportConnection listener
+	 */
+	public TcpTransportConnection(TcpSocket socket, int max_message_size, SipTransportConnectionListener listener) throws IOException {
+		init(socket,max_message_size,listener);
 	}
 
 
 	/**
 	 * Inits the TcpTransportConnection.
-	 * 
+	 *
 	 * @param socket
 	 *        the TCP socket
+	 * @param max_message_size
+	 *        the maximum size of a single received SIP message (in bytes)
 	 * @param listener
 	 *        the TcpTransportConnection listener
 	 */
-	private void init(TcpSocket socket, SipTransportConnectionListener listener) throws IOException {
+	private void init(TcpSocket socket, int max_message_size, SipTransportConnectionListener listener) throws IOException {
 		this.listener=listener;
+		this.buffer=new SipMessageBuffer(max_message_size);
 		TcpConnectionListener this_tcp_conn_listener=new TcpConnectionListener() {
 			@Override
 			public void onReceivedData(TcpConnection tcp_conn, byte[] data, int len) {
@@ -228,13 +248,25 @@ public class TcpTransportConnection implements SipTransportConnection/*, TcpConn
 
 	/** Tries to get a SIP message from the receiver buffer. */
 	private SipMessage getSipMessage()   {
-		SipMessage msg=null;
 		// skip possible leading CRLF
 		byte b;
 		while (buffer.getLength()>0 && ((b=buffer.byteAt(0))=='\r' || b=='\n')) buffer.skip(1);
 		// try to get a SIP message
-		try {  msg=buffer.parseSipMessage();  } catch (Exception e) {}
-		return msg;
+		try {
+			return buffer.parseSipMessage();
+		}
+		catch (IncompleteSipMessageException e) {
+			// The message has not been completely received yet, retry when more data arrives.
+			return null;
+		}
+		catch (Exception e) {
+			// The message cannot be framed, so where the next message starts within the stream is
+			// unknown. Continuing would mean to interpret arbitrary bytes as a message, therefore the
+			// connection must not be used any longer (see RFC 3261, 18.3).
+			LOG.warn("Closing connection {} due to a framing error: {}", connection_id, e.getMessage());
+			halt();
+			return null;
+		}
 	}
 
 }

--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/TlsTransport.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/TlsTransport.java
@@ -178,7 +178,7 @@ public class TlsTransport extends SipTransportCO/* implements TcpServerListener*
 		LOG.debug("incoming connection from {}:{}", socket.getAddress(), socket.getPort());
 		if (tcp_server==this.tls_server) {
 			try {
-				SipTransportConnection conn = new TlsTransportConnection(socket, this_conn_listener);
+				SipTransportConnection conn = new TlsTransportConnection(socket, getMaxMessageSize(), this_conn_listener);
 				LOG.debug("tls connection {} opened", conn);
 				addConnection(conn);
 				if (listener != null)
@@ -201,7 +201,7 @@ public class TlsTransport extends SipTransportCO/* implements TcpServerListener*
 	@Override
 	protected SipTransportConnection createTransportConnection(SocketAddress remote_soaddr) throws IOException {
 		TcpSocket tls_socket=tls_socket_factory.createTlsSocket(remote_soaddr.getAddress(),remote_soaddr.getPort());
-		return new TlsTransportConnection(tls_socket,this_conn_listener);
+		return new TlsTransportConnection(tls_socket,getMaxMessageSize(),this_conn_listener);
 	}
 
 

--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/TlsTransportConnection.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/TlsTransportConnection.java
@@ -55,6 +55,21 @@ public class TlsTransportConnection extends TcpTransportConnection {
 	}
 
 
+	/**
+	 * Constructs a new TlsTransportConnection
+	 *
+	 * @param socket
+	 *        the TLS socket
+	 * @param max_message_size
+	 *        the maximum size of a single received SIP message (in bytes)
+	 * @param listener
+	 *        the TlsTransportConnection listener
+	 */
+	public TlsTransportConnection(TcpSocket socket, int max_message_size, SipTransportConnectionListener listener) throws IOException {
+		super(socket,max_message_size,listener);
+	}
+
+
 	/** Gets protocol type */ 
 	@Override
 	public String getProtocol() {

--- a/mjsip-sip/src/main/java/org/mjsip/sip/provider/UdpTransport.java
+++ b/mjsip-sip/src/main/java/org/mjsip/sip/provider/UdpTransport.java
@@ -24,7 +24,9 @@ package org.mjsip.sip.provider;
 
 import java.io.IOException;
 
+import org.mjsip.sip.message.MalformedSipMessageException;
 import org.mjsip.sip.message.SipMessage;
+import org.slf4j.LoggerFactory;
 import org.zoolu.net.IpAddress;
 import org.zoolu.net.UdpPacket;
 import org.zoolu.net.UdpProvider;
@@ -35,7 +37,9 @@ import org.zoolu.util.ByteUtils;
 /** UdpTransport provides an UDP transport service for SIP.
   */
 public class UdpTransport implements SipTransport/*, UdpProviderListener*/ {
-	
+
+	private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(UdpTransport.class);
+
 	/** Ping data */
 	static final byte[] PING=new byte[]{0x0d,0x0a,0x0d,0x0a}; // CRLF CRCF (RFC5626 PING)
 	
@@ -167,7 +171,17 @@ public class UdpTransport implements SipTransport/*, UdpProviderListener*/ {
 			// do something..
 		}
 		else {
-			SipMessage msg=new SipMessage(packet.getData(),packet.getOffset(),packet.getLength());
+			SipMessage msg;
+			try {
+				msg=SipMessage.parse(packet.getData(),packet.getOffset(),packet.getLength());
+			}
+			catch (MalformedSipMessageException e) {
+				// Note: A partially parsed message must not be passed on, since it may lack even the
+				// request line or the Via header field.
+				LOG.info("Dropping malformed message from {}:{}: {}",packet.getIpAddress(),
+						Integer.valueOf(packet.getPort()),e.getMessage());
+				return;
+			}
 			msg.setRemoteAddress(packet.getIpAddress().toString());
 			msg.setRemotePort(packet.getPort());
 			msg.setTransportProtocol(PROTO_UDP);

--- a/mjsip-sip/src/test/java/org/mjsip/sip/message/TestSipMessageFraming.java
+++ b/mjsip-sip/src/test/java/org/mjsip/sip/message/TestSipMessageFraming.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package org.mjsip.sip.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for framing SIP messages, especially for messages announcing a body length that does not
+ * match the number of bytes actually received.
+ *
+ * @see BasicSipMessage#setMessage(byte[], int, int, boolean)
+ * @see SipMessageBuffer
+ */
+@SuppressWarnings("javadoc")
+class TestSipMessageFraming {
+
+	/** Message header without a Content-Length header field, terminated by an empty line. */
+	private static final String HEADER=
+		"INVITE sip:bob@example.com SIP/2.0\r\n"+
+		"Via: SIP/2.0/TCP client.example.com:5060;branch=z9hG4bK74bf9\r\n"+
+		"From: <sip:alice@example.com>;tag=9fxced76sl\r\n"+
+		"To: <sip:bob@example.com>\r\n"+
+		"Call-ID: 3848276298220188511@client.example.com\r\n"+
+		"CSeq: 1 INVITE\r\n"+
+		"Content-Type: application/sdp\r\n";
+
+	// **************************** Datagram transport ****************************
+
+	@Test
+	void testCompleteMessage() throws MalformedSipMessageException {
+		byte[] packet=bytes(message("v=0\r\n"));
+
+		SipMessage msg=new SipMessage();
+		assertEquals(packet.length,msg.setMessage(packet,0,packet.length));
+		assertEquals("v=0\r\n",msg.getStringBody());
+	}
+
+	/**
+	 * A Content-Length header field announcing a huge body must be rejected instead of trying to
+	 * allocate a buffer of the announced size, which formerly produced an {@link OutOfMemoryError}
+	 * that could not be caught by the callers expecting a {@link MalformedSipMessageException}.
+	 */
+	@Test
+	void testHugeContentLength() {
+		assertMalformed("Content-Length: 2000000000\r\n","v=0\r\n",false);
+		assertMalformed("Content-Length: "+Integer.MAX_VALUE+"\r\n","v=0\r\n",false);
+	}
+
+	/** A Content-Length header field that does not even fit into an <code>int</code>. */
+	@Test
+	void testContentLengthOverflow() {
+		assertMalformed("Content-Length: 99999999999999999999\r\n","v=0\r\n",false);
+	}
+
+	@Test
+	void testNegativeContentLength() {
+		assertMalformed("Content-Length: -1\r\n","v=0\r\n",false);
+		assertMalformed("Content-Length: "+Integer.MIN_VALUE+"\r\n","v=0\r\n",false);
+	}
+
+	/** A body that is announced longer than the received one is an error in a datagram transport. */
+	@Test
+	void testTruncatedBody() {
+		assertMalformed("Content-Length: 100\r\n","v=0\r\n",false);
+	}
+
+	@Test
+	void testMissingHeaderDelimiter() {
+		byte[] packet=bytes(HEADER);
+
+		assertMalformed(packet,false);
+	}
+
+	/** Bytes following the announced body within the same datagram must be discarded. */
+	@Test
+	void testExtraBytesInPacketDiscarded() throws MalformedSipMessageException {
+		String msg_str=message("v=0\r\n");
+		byte[] packet=bytes(msg_str+"INVITE sip:eve@example.com SIP/2.0\r\n\r\n");
+
+		SipMessage msg=new SipMessage();
+		assertEquals(msg_str.length(),msg.setMessage(packet,0,packet.length));
+		assertEquals("v=0\r\n",msg.getStringBody());
+	}
+
+	/** Without a Content-Length header field, the body of a datagram ends at the end of the packet. */
+	@Test
+	void testMissingContentLength() throws MalformedSipMessageException {
+		byte[] packet=bytes(HEADER+"\r\n"+"v=0\r\n");
+
+		SipMessage msg=new SipMessage();
+		assertEquals(packet.length,msg.setMessage(packet,0,packet.length));
+		assertEquals("v=0\r\n",msg.getStringBody());
+	}
+
+	/** A message body is not limited to the size of the receive buffer of a datagram transport. */
+	@Test
+	void testLargeBody() throws MalformedSipMessageException {
+		String body=body(64*1024);
+		byte[] packet=bytes(message(body));
+
+		SipMessage msg=new SipMessage();
+		assertEquals(packet.length,msg.setMessage(packet,0,packet.length));
+		assertEquals(body,msg.getStringBody());
+	}
+
+	@Test
+	void testEmptyBody() throws MalformedSipMessageException {
+		byte[] packet=bytes(message(""));
+
+		SipMessage msg=new SipMessage();
+		assertEquals(packet.length,msg.setMessage(packet,0,packet.length));
+		assertNull(msg.getBody());
+	}
+
+	/** A message may start at an offset within the given buffer. */
+	@Test
+	void testMessageAtOffset() throws MalformedSipMessageException {
+		String msg_str=message("v=0\r\n");
+		byte[] packet=bytes("junk"+msg_str);
+
+		SipMessage msg=new SipMessage();
+		assertEquals(msg_str.length(),msg.setMessage(packet,4,packet.length-4));
+		assertEquals("v=0\r\n",msg.getStringBody());
+	}
+
+	/** The message body must be taken from the first empty line on, also for a LF-only sender. */
+	@Test
+	void testLfOnlyHeaderDelimiter() throws MalformedSipMessageException {
+		String msg_str=HEADER.replace("\r\n","\n")+"Content-Length: 5\n"+"\n"+"v=0\r\n";
+		byte[] packet=bytes(msg_str);
+
+		SipMessage msg=new SipMessage();
+		assertEquals(msg_str.length(),msg.setMessage(packet,0,packet.length));
+		assertEquals("v=0\r\n",msg.getStringBody());
+	}
+
+	/**
+	 * A message received from the network must be rejected instead of being delivered as a partially
+	 * parsed message that may lack even the request line.
+	 */
+	@Test
+	void testParse() throws MalformedSipMessageException {
+		byte[] valid=bytes(message("v=0\r\n"));
+		assertEquals("v=0\r\n",SipMessage.parse(valid,0,valid.length).getStringBody());
+
+		byte[] invalid=bytes(message("Content-Length: 100\r\n","v=0\r\n"));
+		assertMalformed(() -> SipMessage.parse(invalid,0,invalid.length));
+	}
+
+	// **************************** Stream transport ****************************
+
+	@Test
+	void testCompleteMessageInStream() throws MalformedSipMessageException {
+		SipMessageBuffer buffer=buffer(message("v=0\r\n"));
+
+		assertEquals("v=0\r\n",buffer.parseSipMessage().getStringBody());
+		assertEquals(0,buffer.getLength());
+	}
+
+	/**
+	 * A message announcing a body shorter than the buffered data must not consume the bytes of the
+	 * message that follows it in the stream.
+	 */
+	@Test
+	void testPipelinedMessages() throws MalformedSipMessageException {
+		SipMessageBuffer buffer=buffer(message("v=0\r\nfirst\r\n")+message("v=0\r\nsecond\r\n"));
+
+		assertEquals("v=0\r\nfirst\r\n",buffer.parseSipMessage().getStringBody());
+		assertEquals("v=0\r\nsecond\r\n",buffer.parseSipMessage().getStringBody());
+		assertEquals(0,buffer.getLength());
+	}
+
+	/** Messages of a stream may be separated by additional CRLF, as sent by keep-alive mechanisms. */
+	@Test
+	void testPipelinedMessagesWithKeepAlive() throws MalformedSipMessageException {
+		SipMessageBuffer buffer=buffer(message("v=0\r\nfirst\r\n")+"\r\n\r\n"+message("v=0\r\nsecond\r\n"));
+
+		assertEquals("v=0\r\nfirst\r\n",buffer.parseSipMessage().getStringBody());
+		skipCrLf(buffer);
+		assertEquals("v=0\r\nsecond\r\n",buffer.parseSipMessage().getStringBody());
+		assertEquals(0,buffer.getLength());
+	}
+
+	/**
+	 * A message announcing a huge body must not lead to allocating a buffer of the announced size,
+	 * which formerly produced an {@link OutOfMemoryError}.
+	 */
+	@Test
+	void testHugeContentLengthInStream() {
+		SipMessageBuffer buffer=buffer("Content-Length: 2000000000\r\n","v=0\r\n");
+
+		// The rest of the announced body may still arrive, but no buffer of the announced size must be
+		// allocated before the data has actually been received.
+		assertIncomplete(buffer);
+	}
+
+	@Test
+	void testNegativeContentLengthInStream() {
+		assertMalformed("Content-Length: -1\r\n","v=0\r\n",true);
+	}
+
+	@Test
+	void testContentLengthOverflowInStream() {
+		assertMalformed("Content-Length: 99999999999999999999\r\n","v=0\r\n",true);
+	}
+
+	/**
+	 * Without a Content-Length header field, the end of a message within a stream cannot be
+	 * determined, so the message must be rejected instead of consuming the bytes of a potentially
+	 * following message.
+	 */
+	@Test
+	void testMissingContentLengthInStream() {
+		SipMessageBuffer buffer=buffer(HEADER+"\r\n"+message("v=0\r\n"));
+
+		assertMalformed(buffer);
+	}
+
+	/** A message header split over multiple packets must be parsed when it is complete. */
+	@Test
+	void testIncompleteHeaderInStream() throws MalformedSipMessageException {
+		String msg_str=message("v=0\r\n");
+		int split=HEADER.length()/2;
+
+		SipMessageBuffer buffer=buffer(msg_str.substring(0,split));
+		assertIncomplete(buffer);
+
+		buffer.append(bytes(msg_str.substring(split)));
+		assertEquals("v=0\r\n",buffer.parseSipMessage().getStringBody());
+		assertEquals(0,buffer.getLength());
+	}
+
+	/** A message body split over multiple packets must be parsed when it is complete. */
+	@Test
+	void testIncompleteBodyInStream() throws MalformedSipMessageException {
+		String body=body(64*1024);
+		String msg_str=message(body);
+		int split=msg_str.length()-body.length()/2;
+
+		SipMessageBuffer buffer=buffer(msg_str.substring(0,split));
+		assertIncomplete(buffer);
+
+		buffer.append(bytes(msg_str.substring(split)+message("v=0\r\n")));
+		assertEquals(body,buffer.parseSipMessage().getStringBody());
+		assertEquals("v=0\r\n",buffer.parseSipMessage().getStringBody());
+		assertEquals(0,buffer.getLength());
+	}
+
+	/**
+	 * Data that does not form a complete message must not be buffered indefinitely, since a peer could
+	 * otherwise exhaust the memory by announcing a huge body, or by never terminating the message
+	 * header.
+	 */
+	@Test
+	void testMessageSizeLimitInStream() throws MalformedSipMessageException {
+		String announced=message("Content-Length: 2000000000\r\n","v=0\r\n");
+		SipMessageBuffer buffer=new SipMessageBuffer(announced.length()+16);
+
+		buffer.append(bytes(announced));
+		assertIncomplete(buffer);
+
+		// The announced body never arrives, but the peer keeps sending.
+		buffer.append(bytes(body(32)));
+		assertMalformed(buffer);
+	}
+
+	/** A message not exceeding the limit must be parsed, whatever the limit is. */
+	@Test
+	void testMessageAtSizeLimitInStream() throws MalformedSipMessageException {
+		String msg_str=message("v=0\r\n");
+		SipMessageBuffer buffer=new SipMessageBuffer(msg_str.length());
+
+		buffer.append(bytes(msg_str));
+		assertEquals("v=0\r\n",buffer.parseSipMessage().getStringBody());
+		assertEquals(0,buffer.getLength());
+	}
+
+	/** A message header that has not been received completely must not be reported as an error. */
+	@Test
+	void testEmptyStream() {
+		assertIncomplete(new SipMessageBuffer());
+		assertIncomplete(buffer(""));
+		assertIncomplete(buffer("INV"));
+	}
+
+	// **************************** Utilities ****************************
+
+	/** Creates a message with a matching Content-Length header field. */
+	private static String message(String body) {
+		return message("Content-Length: "+bytes(body).length+"\r\n",body);
+	}
+
+	/** Creates a message with the given Content-Length header field, which may be wrong. */
+	private static String message(String content_length, String body) {
+		return HEADER+content_length+"\r\n"+body;
+	}
+
+	/** A body of the given length. */
+	private static String body(int len) {
+		StringBuilder result=new StringBuilder("v=0\r\n");
+		while (result.length()<len) result.append("a=filler:").append(result.length()).append("\r\n");
+		return result.substring(0,len);
+	}
+
+	private static byte[] bytes(String str) {
+		return str.getBytes(StandardCharsets.UTF_8);
+	}
+
+	private static SipMessageBuffer buffer(String data) {
+		return new SipMessageBuffer().append(bytes(data));
+	}
+
+	private static SipMessageBuffer buffer(String content_length, String body) {
+		return buffer(message(content_length,body));
+	}
+
+	/** Skips CRLF sent between messages of a stream, as TcpTransportConnection does. */
+	private static void skipCrLf(SipMessageBuffer buffer) {
+		byte b;
+		while (buffer.getLength()>0 && ((b=buffer.byteAt(0))=='\r' || b=='\n')) buffer.skip(1);
+	}
+
+	/** Checks that a message with the given (invalid) Content-Length header field is rejected. */
+	private static void assertMalformed(String content_length, String body, boolean stream) {
+		if (stream) assertMalformed(buffer(content_length,body));
+		else assertMalformed(bytes(message(content_length,body)),false);
+	}
+
+	private static void assertMalformed(byte[] packet, boolean stream) {
+		SipMessage msg=new SipMessage();
+		assertMalformed(() -> msg.setMessage(packet,0,packet.length,stream));
+	}
+
+	private static void assertMalformed(SipMessageBuffer buffer) {
+		int length=buffer.getLength();
+		assertMalformed(() -> buffer.parseSipMessage());
+		assertEquals(length,buffer.getLength(),"Buffer must not be consumed by a failed parse.");
+	}
+
+	/** Checks that parsing fails in a way that must not be retried. */
+	private static void assertMalformed(Parse parse) {
+		MalformedSipMessageException problem=assertThrows(MalformedSipMessageException.class,() -> parse.run());
+		assertFalse(problem instanceof IncompleteSipMessageException,
+			"Message must be rejected, not be waited for: "+problem.getMessage());
+	}
+
+	/** Checks that parsing fails in a way that may be retried when more data has been received. */
+	private static void assertIncomplete(SipMessageBuffer buffer) {
+		int length=buffer.getLength();
+		assertThrows(IncompleteSipMessageException.class,() -> buffer.parseSipMessage());
+		assertEquals(length,buffer.getLength(),"Buffer must not be consumed by an incomplete message.");
+	}
+
+	/** A parse operation that may fail. */
+	private interface Parse {
+		void run() throws MalformedSipMessageException;
+	}
+
+}

--- a/mjsip-sip/src/test/java/org/mjsip/sip/provider/TestUdpTransport.java
+++ b/mjsip-sip/src/test/java/org/mjsip/sip/provider/TestUdpTransport.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package org.mjsip.sip.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.mjsip.sip.message.SipMessage;
+import org.zoolu.net.IpAddress;
+import org.zoolu.net.SocketAddress;
+import org.zoolu.net.UdpPacket;
+import org.zoolu.net.UdpSocket;
+
+/**
+ * Test for receiving SIP messages over {@link UdpTransport}.
+ */
+class TestUdpTransport {
+
+	/** Maximum time to wait for the messages to be delivered. */
+	private static final int TIMEOUT_MS=5000;
+
+	/** Message header of a request with a body of five bytes. */
+	private static final String HEADER=
+		"INVITE sip:bob@example.com SIP/2.0\r\n"+
+		"Via: SIP/2.0/UDP client.example.com:5060;branch=z9hG4bK74bf9\r\n"+
+		"From: <sip:alice@example.com>;tag=9fxced76sl\r\n"+
+		"To: <sip:bob@example.com>\r\n"+
+		"Call-ID: 3848276298220188511@client.example.com\r\n"+
+		"CSeq: 1 INVITE\r\n"+
+		"Content-Type: application/sdp\r\n";
+
+	/**
+	 * A datagram that cannot be parsed must be dropped instead of being delivered as a partially
+	 * parsed message, and it must not stop the transport from receiving the messages that follow.
+	 */
+	@Test
+	void testMalformedDatagramDropped() throws IOException, InterruptedException {
+		// Note: The last message is valid, so that receiving it proves that the preceding invalid ones
+		// have been processed (datagrams are delivered in order over the loopback interface).
+		List<String> datagrams=List.of(
+			HEADER+"Content-Length: 2000000000\r\n\r\nv=0\r\n",
+			HEADER+"Content-Length: -1\r\n\r\nv=0\r\n",
+			HEADER+"Content-Length: 100\r\n\r\nv=0\r\n",
+			"not a SIP message at all",
+			HEADER+"Content-Length: 5\r\n\r\nv=0\r\n");
+
+		CountDownLatch received=new CountDownLatch(1);
+		List<SipMessage> messages=new ArrayList<>();
+
+		SipTransportListener listener=new SipTransportListener() {
+			@Override
+			public void onReceivedMessage(SipTransport transport, SipMessage msg) {
+				synchronized (messages) {
+					messages.add(msg);
+				}
+				received.countDown();
+			}
+
+			@Override
+			public void onIncomingTransportConnection(SipTransport transport, SocketAddress remote_soaddr) {
+				// Ignore.
+			}
+
+			@Override
+			public void onTransportConnectionTerminated(SipTransport transport, SocketAddress remote_soaddr, Exception error) {
+				// Ignore.
+			}
+
+			@Override
+			public void onTransportTerminated(SipTransport transport, Exception error) {
+				// Ignore.
+			}
+		};
+
+		IpAddress localhost=new IpAddress(InetAddress.getLoopbackAddress());
+		try (UdpSocket sender=new UdpSocket(0,localhost)) {
+			UdpTransport transport=new UdpTransport(0,localhost);
+			transport.setListener(listener);
+			try {
+				for (String datagram : datagrams) {
+					byte[] buf=datagram.getBytes(StandardCharsets.UTF_8);
+					sender.send(new UdpPacket(buf,buf.length,localhost,transport.getLocalPort()));
+				}
+
+				assertTrue(received.await(TIMEOUT_MS,TimeUnit.MILLISECONDS),"The valid message has not been received.");
+				synchronized (messages) {
+					assertEquals(1,messages.size(),"Only the valid message must be delivered.");
+					SipMessage msg=messages.get(0);
+					assertEquals("v=0\r\n",msg.getStringBody());
+					assertEquals("INVITE",msg.getRequestLine().getMethod());
+				}
+			}
+			finally {
+				transport.halt();
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
## The problem

A `Content-Length` header field value was used directly as an allocation and copy length, without ever being compared to the number of bytes actually received. `ByteUtils.copy(buf, off+siph_len, body_len)` does `new byte[body_len]`.

A single UDP datagram announcing `Content-Length: 2000000000` therefore triggered a 2 GB allocation attempt, producing an **`OutOfMemoryError`** — an `Error`, so it slipped past every `catch (Exception e)` on its way out: the parser's own catch, the `BasicSipMessage` constructor, and, fatally, the listener call in `UdpProvider.run()`. The receive loop unwound, the thread died, and the stack stopped receiving anything at all. One spoofable packet, permanent deafness.

Milder variants of the same input (negative, or oversized-but-affordable) were caught, but on a stream transport `setMessage()` still returned `siph_len+body_len`, which `SipMessageBuffer` adds to its offset — so an inflated value pushed the offset past the buffer end and broke a *later* packet on a connection whose earlier message had parsed "fine".

## The fix

The body length is checked against the bytes actually received before anything is allocated (`BasicSipMessage.checkBodyLength`). Since a stream-oriented transport delivers a message in several chunks, framing had to become transport-aware — `setMessage(byte[],int,int,boolean stream)`, per RFC 3261 §18.3:

- **Datagram**: a body announced longer than the one received is an error; bytes following the body are discarded.
- **Stream**: the missing bytes may still arrive, reported by the new `IncompleteSipMessageException`, so `TcpTransportConnection` can distinguish "wait for more data" from "cannot be framed". A message that cannot be framed now closes the connection — continuing would mean interpreting arbitrary bytes as the next message.
- **Stream without `Content-Length`**: rejected, instead of swallowing `len-siph_len` bytes that may well belong to a subsequent message. That was the actual framing hole: what counted as "the body" depended on TCP segmentation, and a pipelined follow-up message got absorbed into it.

Related hardening in the same area:

- The message header ends at the **first** empty line, whether `CRLFCRLF` or `LFLF`. Searching the whole buffer for `CRLFCRLF` first could pick a delimiter belonging to the next message in a stream.
- Buffered data that does not form a complete message is bounded by `SipMessageBuffer.DEFAULT_MAX_MESSAGE_SIZE` (1 MB), configurable via `--max-message-size` / `SipOptions.getMaxMessageSize()`. Without a limit, a peer could exhaust memory by announcing a huge body and sending it slowly. New constructor overloads carry the value to the buffer; existing constructors delegate with the default, so no signature outside changed.
- `UdpProvider` survives an `Error` raised while processing a single packet — a failure for one peer must not stop the service for all — and logs it instead of discarding it silently.
- A packet that cannot be parsed is dropped by `UdpTransport`, using the new `SipMessage.parse()`. The `SipMessage(byte[],int,int)` constructor only *logs* a parser error, so a message lacking even its request line used to be handed to the stack.

## Tests

`mvn test` is green across the reactor (66 tests).

- **`TestSipMessageFraming`** (25) — huge / `MAX_VALUE` / overflowing / negative / truncated `Content-Length` on both transports; a 64 KB body accepted; pipelining with distinct bodies; header-split and body-split resumption; missing `Content-Length` on a stream rejected as malformed rather than awaited; the size limit; the buffer never consumed by a failed parse.
- **`TestUdpTransport`** — drives the real receive path over a loopback socket: four bad datagrams followed by a valid one, asserting exactly one message reaches the listener, with request line and body intact.
- **`TestUdpProvider`** — a listener throwing `OutOfMemoryError` on one packet and `IllegalStateException` on the next: the receiver thread stays alive and the following packet is still processed.

Both regressions were verified to be caught: stubbing out `checkBodyLength` kills the forked test JVM outright with `Requested array size exceeds VM limit` (precisely why the old `catch (Exception e)` could never help), and restoring `new SipMessage(...)` in `UdpTransport` fails with `expected: <1> but was: <2>`, the extra one being a partially parsed message.

## Compatibility note

`SipOptions.getMaxMessageSize()` is a `default` method so external implementors keep compiling. `SipTransportCO.setMaxMessageSize()` applies to connections established afterwards (following the existing `setForceSentBy` pattern); a connection accepted before `SipProvider` applies the setting gets the 1 MB default, so the race can only miss a deliberate relaxation of the limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)