### PR TITLE
Validate the lengths announced by received RTP and RTCP packets

### DIFF
--- a/mjsip-sip/src/main/java/org/mjsip/media/RtpStreamReceiver.java
+++ b/mjsip-sip/src/main/java/org/mjsip/media/RtpStreamReceiver.java
@@ -286,22 +286,29 @@ public class RtpStreamReceiver implements Runnable, RtpControlledReceiver {
 						byte[] payload_buf=rtp_packet.getPacketBuffer();
 						int payload_off=rtp_packet.getHeaderLength();
 						int payload_len=rtp_packet.getPayloadLength();
-						
-						// remove possible RTP payload format
-						int unformatted_len=(rtp_payload_format!=null)? rtp_payload_format.removeRtpPayloadFormat(payload_buf,payload_off,payload_len) : payload_len;
-					
-						// drop a small percentage of packets
-						if (random_early_drop>0 && (++packet_counter)%random_early_drop==0) continue;
-						// else 
 
-						if (additional_decoder!=null) unformatted_len=additional_decoder.encode(payload_buf,payload_off,unformatted_len,payload_buf,payload_off);
-
-						// write the payload data to the output_stream
+						// Note: A packet that cannot be processed must not terminate the reception,
+						// since that would end the media stream for the whole call.
 						try {
+							// remove possible RTP payload format
+							int unformatted_len=(rtp_payload_format!=null)? rtp_payload_format.removeRtpPayloadFormat(payload_buf,payload_off,payload_len) : payload_len;
+
+							// drop a small percentage of packets
+							if (random_early_drop>0 && (++packet_counter)%random_early_drop==0) continue;
+							// else
+
+							if (additional_decoder!=null) unformatted_len=additional_decoder.encode(payload_buf,payload_off,unformatted_len,payload_buf,payload_off);
+
+							// write the payload data to the output_stream
 							output_stream.write(payload_buf,payload_off,unformatted_len);
 						}
+						catch (RuntimeException e) {
+							LOG.warn("Dropping RTP packet that could not be processed (offset={}, length={}).",
+									Integer.valueOf(payload_off),Integer.valueOf(payload_len),e);
+						}
 						catch (IOException e) {
-							System.out.println("DEBUG: RtpStreamReceiver: write(buf,off="+payload_off+", len="+unformatted_len+"): error: "+e);
+							LOG.warn("Writing the received payload failed (offset={}, length={}).",
+									Integer.valueOf(payload_off),Integer.valueOf(payload_len),e);
 							throw e;
 						}
 					}

--- a/mjsip-sip/src/main/java/org/mjsip/rtp/RtcpCompoundPacket.java
+++ b/mjsip-sip/src/main/java/org/mjsip/rtp/RtcpCompoundPacket.java
@@ -93,13 +93,20 @@ public class RtcpCompoundPacket {
 		return length;
 	}
 
-	/** Gets the RTCP packets componing the compound packet. */
+	/** Gets the RTCP packets componing the compound packet.
+	  * <p>
+	  * Packets that are not completely contained in the received data are dropped, since their length
+	  * is announced by the packets themselves and may exceed the data actually received.
+	  * </p>
+	  * @return the RTCP packets found in the compound packet */
 	public RtcpPacket[] getRtcpPackets() {
 		int index=0;
 		Vector<RtcpPacket> aux=new Vector<>();
-		while (index<length) {
+		while (index+RtcpPacket.HDR_LEN<=length) {
 			RtcpPacket rp=new RtcpPacket(buffer,offset+index);
-			index+=rp.getPacketLength();
+			int packet_len=rp.getPacketLength();
+			if (packet_len<RtcpPacket.HDR_LEN || index+packet_len>length) break; // broken packet
+			index+=packet_len;
 			aux.addElement(rp);
 		}
 		RtcpPacket[] rtcp_packets=new RtcpPacket[aux.size()];

--- a/mjsip-sip/src/main/java/org/mjsip/rtp/RtcpPacket.java
+++ b/mjsip-sip/src/main/java/org/mjsip/rtp/RtcpPacket.java
@@ -27,7 +27,10 @@ package org.mjsip.rtp;
 /** RTCP packet, as defined by RFC 3550. 
  */
 public class RtcpPacket {
-	
+
+	/** Length of the RTCP common header (V, P, PT, and length) */
+	public static final int HDR_LEN=4;
+
 	/** SR (Sendr Report) RTCP packet type */
 	public static final int PT_SR=200;
 
@@ -105,9 +108,17 @@ public class RtcpPacket {
 	/** Gets padding length
 	  * @return the number of padding bytes */
 	public int getPaddingLength() {
+		int packet_len=getPacketLength();
+		if (packet_len<=HDR_LEN) return 0; // broken packet, or no room for padding
+		// else
 		boolean p=BufferUtil.getBit(buffer[offset],5);
-		if (p) return buffer[offset+getPacketLength()-1];
-		else return 0;
+		if (!p) return 0;
+		// else
+		int padding_len=buffer[offset+packet_len-1] & 0xFF; // the padding length is an unsigned value
+		// Note: The padding length is announced by the packet itself, therefore it may be larger than
+		// the number of bytes actually received.
+		int available=packet_len-HDR_LEN;
+		return (padding_len<=available)? padding_len : available;
 	}
 
 	/** Sets padding length.
@@ -137,15 +148,22 @@ public class RtcpPacket {
 	}
 
 	/** Gets the RTCP packet length.
-	  * @return the RTCP packet length including the header and any padding */   
+	  * @return the RTCP packet length including the header and any padding; never more than the number
+	  *         of bytes available after the packet offset */
 	public int getPacketLength() {
-		return (BufferUtil.getInt(buffer,2,4)+1)*4;
+		int available=buffer.length-offset;
+		if (available<HDR_LEN) return (available>0)? available : 0; // broken packet
+		// else
+		int packet_len=(BufferUtil.getInt(buffer,offset+2,offset+4)+1)*4;
+		// Note: The length is announced by the packet itself, therefore it may be larger than the
+		// number of bytes actually received.
+		return (packet_len<=available)? packet_len : available;
 	}
 
 	/** Sets the RTCP packet length.
-	  * @param len the RTCP packet length including the header and any padding */   
+	  * @param len the RTCP packet length including the header and any padding */
 	public void setPacketLength(int len) {
-		BufferUtil.setInt(len/4-1,buffer,2,4);
+		BufferUtil.setInt(len/4-1,buffer,offset+2,offset+4);
 	}
 
 }

--- a/mjsip-sip/src/main/java/org/mjsip/rtp/RtpPacket.java
+++ b/mjsip-sip/src/main/java/org/mjsip/rtp/RtpPacket.java
@@ -189,8 +189,22 @@ public class RtpPacket {
 		if (length<HDR_LEN) return 0; // broken packet
 		// else
 		boolean p=BufferUtil.getBit(buffer[offset],5);
-		if (p) return buffer[offset+length-1];
-		else return 0;
+		if (!p) return 0;
+		// else
+		int padding_len=buffer[offset+length-1] & 0xFF; // the padding length is an unsigned value
+		// Note: The padding length is announced by the packet itself, therefore it may be larger than
+		// the number of bytes actually received. Such a packet is broken and has no payload at all.
+		int available=getAvailableLength();
+		return (padding_len<=available)? padding_len : available;
+	}
+
+	/** Gets the number of received bytes following the RTP header, i.e. the bytes available for the
+	  * payload and for the padding.
+	  * @return the number of bytes following the RTP header, or 0 if the announced header does not fit
+	  *         into the received packet */
+	private int getAvailableLength() {
+		int available=length-getHeaderLength();
+		return (available>0)? available : 0; // returns 0 in case of broken packet
 	}
 
 	/** Sets padding length.
@@ -386,8 +400,12 @@ public class RtpPacket {
 	/** Gets the RTP header length.
 	  * @return the RTP header length */
 	public int getHeaderLength() {
-		if (length>=HDR_LEN) return HDR_LEN+4*getCsrcCount();
-		else return length; // broken packet
+		if (length<HDR_LEN) return length; // broken packet
+		// else
+		int hdr_len=HDR_LEN+4*getCsrcCount();
+		// Note: The CSRC count is announced by the packet itself, therefore the announced header may
+		// be longer than the number of bytes actually received.
+		return (hdr_len<=length)? hdr_len : length; // broken packet
 	}
 
 	/** Sets the RTP payload.
@@ -411,20 +429,19 @@ public class RtpPacket {
 	}
 
 	/** Gets the payload.
-	  * @return a new byte array containing the the payload data */ 
+	  * @return a new byte array containing the the payload data (without any padding) */
 	public byte[] getPayload() {
 		int hdr_len=getHeaderLength();
-		int pl_len=length-hdr_len;
+		int pl_len=getPayloadLength();
 		byte[] pl_buf=new byte[pl_len];
-		for (int i=0; i<pl_len; i++) pl_buf[i]=buffer[offset+hdr_len+i]; 
+		for (int i=0; i<pl_len; i++) pl_buf[i]=buffer[offset+hdr_len+i];
 		return pl_buf;
 	}
 
 	/** Gets the RTP payload length.
-	  * @return the RTP payload length */
+	  * @return the RTP payload length; never more than the number of bytes actually received */
 	public int getPayloadLength() {
-		int pl_len=length-getHeaderLength()-getPaddingLength();
-		return (pl_len>0)? pl_len : 0; // returns 0 in case of broken packet
+		return getAvailableLength()-getPaddingLength();
 	}
 
 	/** Sets the RTP payload length.

--- a/mjsip-sip/src/test/java/org/mjsip/rtp/TestRtcpPacket.java
+++ b/mjsip-sip/src/test/java/org/mjsip/rtp/TestRtcpPacket.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package org.mjsip.rtp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for framing received RTCP packets, whose length is announced by the packets themselves.
+ */
+@SuppressWarnings("javadoc")
+class TestRtcpPacket {
+
+	/** Size of the buffer a RTCP packet is received into. */
+	private static final int BUFFER_SIZE=1024;
+
+	@Test
+	void testPacketLength() {
+		byte[] buffer=new byte[BUFFER_SIZE];
+		RtcpPacket packet=new RtcpPacket(buffer);
+		packet.setVersion(2);
+		packet.setPacketLength(28);
+
+		assertEquals(28,packet.getPacketLength());
+		assertEquals(0,packet.getPaddingLength());
+	}
+
+	/** The length field of a packet at an offset must be read at that offset. */
+	@Test
+	void testPacketLengthAtOffset() {
+		byte[] buffer=new byte[BUFFER_SIZE];
+		RtcpPacket first=new RtcpPacket(buffer,0);
+		first.setPacketLength(8);
+		RtcpPacket second=new RtcpPacket(buffer,8);
+		second.setPacketLength(28);
+
+		assertEquals(8,first.getPacketLength());
+		assertEquals(28,second.getPacketLength());
+	}
+
+	/**
+	 * A packet announcing a length beyond the received data must not lead to reading beyond the
+	 * buffer.
+	 */
+	@Test
+	void testExcessivePacketLength() {
+		byte[] buffer=new byte[64];
+		buffer[0]=(byte)0xA0; // version 2, padding bit set
+		buffer[2]=(byte)0xFF; // length: (0xFFFF + 1) * 4 = 262144 bytes
+		buffer[3]=(byte)0xFF;
+		RtcpPacket packet=new RtcpPacket(buffer);
+
+		assertTrue(packet.getPacketLength()<=buffer.length,
+			"Announced length "+packet.getPacketLength()+" exceeds the received "+buffer.length+" bytes.");
+		// Must not throw, whatever the packet announces.
+		assertTrue(packet.getPaddingLength()<=packet.getPacketLength());
+	}
+
+	/** A packet whose header is not completely received must not be read beyond the buffer. */
+	@Test
+	void testTruncatedHeader() {
+		byte[] buffer=new byte[6];
+		RtcpPacket packet=new RtcpPacket(buffer,4);
+
+		assertTrue(packet.getPacketLength()<=2);
+		assertEquals(0,packet.getPaddingLength());
+	}
+
+	/** The padding length is an unsigned value. */
+	@Test
+	void testUnsignedPaddingLength() {
+		for (int padding=0x80; padding<=0xFF; padding++) {
+			byte[] buffer=new byte[BUFFER_SIZE];
+			RtcpPacket packet=new RtcpPacket(buffer);
+			packet.setVersion(2);
+			packet.setPacketLength(28);
+			buffer[0]|=0x20; // padding (P) bit
+			buffer[27]=(byte)padding;
+
+			assertTrue(packet.getPaddingLength()>=0,"Padding length must not be negative.");
+			assertTrue(packet.getPaddingLength()<=28-RtcpPacket.HDR_LEN,
+				"Padding of "+packet.getPaddingLength()+" exceeds the packet.");
+		}
+	}
+
+	/** All packets of a compound packet must be found. */
+	@Test
+	void testCompoundPacket() {
+		byte[] buffer=new byte[BUFFER_SIZE];
+		RtcpPacket first=new RtcpPacket(buffer,0);
+		first.setVersion(2);
+		first.setPacketLength(8);
+		RtcpPacket second=new RtcpPacket(buffer,8);
+		second.setVersion(2);
+		second.setPacketLength(28);
+
+		RtcpPacket[] packets=new RtcpCompoundPacket(buffer,0,36).getRtcpPackets();
+
+		assertEquals(2,packets.length);
+		assertEquals(0,packets[0].getPacketOffset());
+		assertEquals(8,packets[1].getPacketOffset());
+		assertEquals(28,packets[1].getPacketLength());
+	}
+
+	/** A packet that is not completely contained in the received data must be dropped. */
+	@Test
+	void testCompoundPacketWithTruncatedPacket() {
+		byte[] buffer=new byte[BUFFER_SIZE];
+		RtcpPacket first=new RtcpPacket(buffer,0);
+		first.setVersion(2);
+		first.setPacketLength(8);
+		RtcpPacket second=new RtcpPacket(buffer,8);
+		second.setVersion(2);
+		second.setPacketLength(28);
+
+		// Only the first packet and a part of the second one have been received.
+		RtcpPacket[] packets=new RtcpCompoundPacket(buffer,0,20).getRtcpPackets();
+
+		assertEquals(1,packets.length);
+		assertEquals(0,packets[0].getPacketOffset());
+	}
+
+	/** A trailing fragment shorter than a RTCP header must be dropped. */
+	@Test
+	void testCompoundPacketWithTrailingFragment() {
+		byte[] buffer=new byte[BUFFER_SIZE];
+		RtcpPacket first=new RtcpPacket(buffer,0);
+		first.setVersion(2);
+		first.setPacketLength(8);
+
+		RtcpPacket[] packets=new RtcpCompoundPacket(buffer,0,10).getRtcpPackets();
+
+		assertEquals(1,packets.length);
+	}
+
+}

--- a/mjsip-sip/src/test/java/org/mjsip/rtp/TestRtpPacket.java
+++ b/mjsip-sip/src/test/java/org/mjsip/rtp/TestRtpPacket.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package org.mjsip.rtp;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for deriving payload offset and length from a received {@link RtpPacket}, especially for
+ * packets announcing a padding or CSRC count that does not match the data actually received.
+ */
+@SuppressWarnings("javadoc")
+class TestRtpPacket {
+
+	/** Size of the receive buffer of {@link org.mjsip.media.RtpStreamReceiver}. */
+	private static final int BUFFER_SIZE=32768;
+
+	/** Length of the RTP header without any CSRC identifier. */
+	private static final int HDR_LEN=12;
+
+	@Test
+	void testPlainPacket() {
+		byte[] payload={ 1, 2, 3, 4, 5 };
+		RtpPacket packet=new RtpPacket(0,4711,1,0,payload,0,payload.length);
+
+		assertEquals(HDR_LEN,packet.getHeaderLength());
+		assertEquals(0,packet.getPaddingLength());
+		assertEquals(payload.length,packet.getPayloadLength());
+		assertArrayEquals(payload,packet.getPayload());
+	}
+
+	@Test
+	void testPacketWithCsrc() {
+		byte[] payload={ 1, 2, 3, 4, 5 };
+		RtpPacket packet=new RtpPacket(0,4711,1,0,new long[] { 1, 2 },payload,0,payload.length);
+
+		assertEquals(HDR_LEN+8,packet.getHeaderLength());
+		assertEquals(payload.length,packet.getPayloadLength());
+		assertArrayEquals(payload,packet.getPayload());
+	}
+
+	/** A received packet with four bytes of payload followed by four bytes of padding. */
+	@Test
+	void testPacketWithPadding() {
+		RtpPacket packet=receivedPacket(HDR_LEN+8);
+		setPadding(packet,4);
+
+		assertEquals(4,packet.getPaddingLength());
+		assertEquals(4,packet.getPayloadLength());
+		assertPayloadWithinPacket(packet);
+	}
+
+	/**
+	 * The padding length is an unsigned value: A padding byte with its highest bit set must not be
+	 * read as a negative length, which would announce a payload longer than the received packet.
+	 */
+	@Test
+	void testUnsignedPaddingLength() {
+		for (int padding=0x80; padding<=0xFF; padding++) {
+			RtpPacket packet=receivedPacket(BUFFER_SIZE);
+			setPadding(packet,padding);
+
+			assertTrue(packet.getPaddingLength()>=0,"Padding length must not be negative.");
+			assertPayloadWithinPacket(packet);
+		}
+	}
+
+	/** A padding length larger than the received packet leaves no payload at all. */
+	@Test
+	void testExcessivePaddingLength() {
+		RtpPacket packet=receivedPacket(HDR_LEN+8);
+		setPadding(packet,100);
+
+		assertEquals(0,packet.getPayloadLength());
+		assertPayloadWithinPacket(packet);
+	}
+
+	/**
+	 * A CSRC count announcing more identifiers than the received packet can hold must not produce a
+	 * negative payload length.
+	 */
+	@Test
+	void testExcessiveCsrcCount() {
+		RtpPacket packet=receivedPacket(HDR_LEN);
+		packet.getPacketBuffer()[0]=(byte)0x8F; // version 2, CSRC count 15
+
+		assertEquals(0,packet.getPayloadLength());
+		assertEquals(0,packet.getPayload().length);
+		assertPayloadWithinPacket(packet);
+	}
+
+	/** A packet shorter than the RTP header has no payload. */
+	@Test
+	void testTruncatedHeader() {
+		RtpPacket packet=receivedPacket(HDR_LEN-1);
+
+		assertEquals(0,packet.getPaddingLength());
+		assertEquals(0,packet.getPayloadLength());
+	}
+
+	/** A packet filling the whole receive buffer must not announce a payload beyond that buffer. */
+	@Test
+	void testPacketFillingTheReceiveBuffer() {
+		RtpPacket packet=receivedPacket(BUFFER_SIZE);
+		setPadding(packet,0x80);
+
+		assertPayloadWithinPacket(packet);
+	}
+
+	// **************************** Utilities ****************************
+
+	/** A packet of the given length, as received into a buffer of the receiver's size. */
+	private static RtpPacket receivedPacket(int length) {
+		byte[] buffer=new byte[BUFFER_SIZE];
+		RtpPacket packet=new RtpPacket(buffer,0,length);
+		if (length>=HDR_LEN) packet.setVersion(2);
+		return packet;
+	}
+
+	/** Announces the given padding length, without writing an actual padding. */
+	private static void setPadding(RtpPacket packet, int padding_len) {
+		byte[] buffer=packet.getPacketBuffer();
+		buffer[packet.getPacketOffset()]|=0x20; // padding (P) bit
+		buffer[packet.getPacketOffset()+packet.getPacketLength()-1]=(byte)padding_len;
+	}
+
+	/**
+	 * Checks that the payload announced by the packet lies within the received data, the way
+	 * {@link org.mjsip.media.RtpStreamReceiver} passes it on.
+	 */
+	private static void assertPayloadWithinPacket(RtpPacket packet) {
+		int off=packet.getHeaderLength();
+		int len=packet.getPayloadLength();
+
+		assertTrue(len>=0,"Payload length must not be negative: "+len);
+		assertTrue(off+len<=packet.getPacketLength(),
+			"Payload ["+off+", "+off+"+"+len+") exceeds the received packet of "+packet.getPacketLength()+" bytes.");
+
+		// Must not throw, whatever the packet announces.
+		new ByteArrayOutputStream().write(packet.getPacketBuffer(),packet.getPacketOffset()+off,len);
+	}
+
+}


### PR DESCRIPTION
Found while scanning for the defect class fixed in #39: a length announced by a received packet used without comparing it to the bytes actually received. The RTP/RTCP layer had the same problem, in a subsystem where the receive loop is not protected by `UdpProvider`.

## RTP

**Padding length was read as a signed byte** — `RtpPacket.getPaddingLength()` returned `buffer[offset+length-1]`, so a padding byte ≥ `0x80` gave a *negative* padding length, and `getPayloadLength()` therefore announced **more** bytes than the packet contains (the clamp there only caught ≤ 0). Measured on the unfixed code, for a datagram filling the receiver's 32768-byte buffer with the P bit set and `0x80` as its last byte:

```
length = 32768, headerLength = 12, paddingLength = -128, payloadLength = 32884
write  = java.lang.IndexOutOfBoundsException: Range [12, 12 + 32884) out of bounds for length 32768
```

That `write` is what `RtpStreamReceiver` does with the values. Shorter datagrams don't throw — they splice up to 127 bytes of the *previously received packet* into the audio output. `ssrc_check` and `sequence_check` both default to `false`, so no SSRC guessing is needed.

**One packet permanently ended media reception.** `RtpStreamReceiver.run()` had its `catch (Exception e)` *outside* the `while (running)` loop, so that exception set `running=false`, closed the socket and terminated the receiver for the whole call. Processing a single packet is now guarded: a packet that cannot be processed is logged and dropped, while I/O errors still terminate the stream as before.

**A CSRC count larger than the packet** produced a header longer than the data, so `getPayload()` did `new byte[12-72]` → `NegativeArraySizeException: -60` for a 12-byte packet with `CC=15`. `getHeaderLength()` now reports no more than the received length — the rule the method already applied to packets shorter than the header — and payload length and offset are derived consistently.

## RTCP

**The announced packet length was used unchecked.** `RtcpPacket.getPacketLength()` returns `(length_field+1)*4`, up to 262144, and `getPaddingLength()` indexed the buffer with it. On a 64-byte datagram:

```
getPacketLength   = 262144   (received 64)
getPaddingLength  = java.lang.ArrayIndexOutOfBoundsException: Index 262143 out of bounds for length 64
```

This one is *contained* — `RtcpProvider` is a `UdpProvider` listener, so the per-packet guard drops the packet instead of killing the thread. It is a bug rather than a DoS only because of that guard. The length is now limited to the data available after the packet offset, and `RtcpCompoundPacket.getRtcpPackets()` drops sub-packets that are not completely contained in the datagram instead of handing out packets pointing past the buffer.

**The length field was read and written at absolute indexes 2 and 3**, ignoring the packet's offset within the buffer. So in a compound packet every sub-packet shared the *first* one's length field — the writes even collide:

```
first.length  = 28 (set 8)     <- overwritten by the second packet
second.length = 28 (set 28)
```

Both now honour `offset`.

## Tests

`mvn test` is green across the reactor; `mjsip-sip` is at 45 tests including the 16 new ones.

- **`TestRtpPacket`** — every padding byte from `0x80` to `0xFF`; padding exceeding the packet; `CC=15` on a 12-byte packet; a truncated header; a packet filling the receive buffer. Each asserts the announced payload lies inside the received packet *and* that the `write` call `RtpStreamReceiver` makes does not throw. Plus round-trips of normal packets, with and without CSRC, so the sender path is unaffected.
- **`TestRtcpPacket`** — inflated length field; truncated header; unsigned padding; compound packets that are complete, truncated mid-packet, or have a trailing fragment shorter than a header; and the length field read at the right offset.

Reverting the fixes and re-running the probes reproduces every "before" figure quoted above.

## Left out of this change

Two bugs found while testing, neither reachable today, both filed instead of fixed here:

- #42 — `RtpPacket.setPaddingLength()` writes the padding outside the packet (sender side; all callers pass 0).
- #43 — `RtcpCompoundPacket(byte[])` leaves `length` at 0 (both receive paths use the constructors that set it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
