### PR TITLE
Keep the TCP receiver threads alive when a callback fails

### DIFF
--- a/mjsip-net/src/main/java/org/zoolu/net/TcpConnection.java
+++ b/mjsip-net/src/main/java/org/zoolu/net/TcpConnection.java
@@ -190,14 +190,20 @@ public class TcpConnection extends Thread {
 					LOG.debug("Connection closed: {}", socket);
 					stop=true;
 				} else if (len > 0) {
-					if (listener!=null) listener.onReceivedData(this,buff,len);
+					// Note: A failure while processing received data must not terminate the connection
+					// handler, since that would leave the connection in an undefined state without
+					// notifying the listener. Errors are caught as well, since e.g. an OutOfMemoryError
+					// may be provoked by malicious data.
+					if (listener!=null) try {  listener.onReceivedData(this,buff,len);  } catch (Throwable t) {
+						LOG.warn("Dropping {} bytes received from {} that could not be processed.",Integer.valueOf(len),socket,t);
+					}
 					if (alive_time>0) expire=System.currentTimeMillis()+alive_time;
 				}
 			}
 		}
-		catch (IOException e) {
-			LOG.info("TCP connection terminated: {}", e.getMessage());
-			error=e;
+		catch (Throwable t) {
+			LOG.info("TCP connection terminated: {}", t.getMessage());
+			error=(t instanceof IOException)? (IOException)t : new IOException(t);
 			stop=true;
 		}
 		is_running=false;

--- a/mjsip-net/src/main/java/org/zoolu/net/TcpServer.java
+++ b/mjsip-net/src/main/java/org/zoolu/net/TcpServer.java
@@ -28,12 +28,16 @@ import java.io.InterruptedIOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 
+import org.slf4j.LoggerFactory;
+
 
 
 /** TcpServer implements a TCP server wainting for incoming connection.
   */
 public class TcpServer extends Thread {
-	
+
+	private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(TcpServer.class);
+
 	/** Default value for the maximum time that the tcp server can remain active after been halted (in milliseconds) */
 	public static final int DEFAULT_SOCKET_TIMEOUT=5000; // 5sec 
 
@@ -153,13 +157,19 @@ public class TcpServer extends Thread {
 					if (alive_time>0 && System.currentTimeMillis()>expire) halt();
 					continue;
 				}
-				if (listener!=null) listener.onIncomingConnection(this,socket);
+				// Note: A failure while handling a single connection must not terminate the server,
+				// since that would stop accepting connections at all. Errors are caught as well, since
+				// e.g. an OutOfMemoryError may be provoked by a malicious peer.
+				if (listener!=null) try {  listener.onIncomingConnection(this,socket);  } catch (Throwable t) {
+					LOG.warn("Refusing connection from {}:{} that could not be handled.",socket.getAddress(),Integer.valueOf(socket.getPort()),t);
+					try {  socket.close();  } catch (Exception e) {}
+				}
 				if (alive_time>0) expire=System.currentTimeMillis()+alive_time;
 			}
 		}
-		catch (Exception e) {
-			error=e;
-			e.printStackTrace();
+		catch (Throwable t) {
+			error=(t instanceof Exception)? (Exception)t : new RuntimeException(t);
+			LOG.warn("TCP server terminated.",t);
 			stop=true;
 		}
 		is_running=false;

--- a/mjsip-net/src/test/java/test/org/zoolu/net/TestTcpReceiveLoops.java
+++ b/mjsip-net/src/test/java/test/org/zoolu/net/TestTcpReceiveLoops.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package test.org.zoolu.net;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.zoolu.net.IpAddress;
+import org.zoolu.net.TcpConnection;
+import org.zoolu.net.TcpConnectionListener;
+import org.zoolu.net.TcpServer;
+import org.zoolu.net.TcpServerListener;
+import org.zoolu.net.TcpSocket;
+
+/**
+ * Test for the robustness of the {@link TcpServer} and {@link TcpConnection} receiver threads.
+ */
+class TestTcpReceiveLoops {
+
+	/** Maximum time to wait for a connection or for data to be delivered. */
+	private static final int TIMEOUT_MS=5000;
+
+	private static final IpAddress LOCALHOST=new IpAddress(InetAddress.getLoopbackAddress());
+
+	/**
+	 * Data that cannot be processed must not terminate the connection handler, since that would leave
+	 * the connection running without ever notifying its listener. This especially holds for an
+	 * {@link Error} such as the {@link OutOfMemoryError} that malicious data may provoke.
+	 */
+	@Test
+	void testConnectionSurvivesFailureWhileProcessingData() throws IOException, InterruptedException {
+		CountDownLatch failed=new CountDownLatch(1);
+		List<String> processed=new ArrayList<>();
+
+		TcpConnectionListener listener=new TcpConnectionListener() {
+			@Override
+			public void onReceivedData(TcpConnection connection, byte[] data, int len) {
+				String received=new String(data,0,len,StandardCharsets.UTF_8);
+				if (received.startsWith("error")) {
+					failed.countDown();
+					throw new OutOfMemoryError("Simulated failure while processing '"+received+"'.");
+				}
+				synchronized (processed) {
+					processed.add(received);
+				}
+			}
+
+			@Override
+			public void onConnectionTerminated(TcpConnection connection, Exception error) {
+				// Ignore.
+			}
+		};
+
+		try (Acceptor acceptor=new Acceptor(); TcpSocket client=new TcpSocket(LOCALHOST,acceptor.getPort())) {
+			TcpSocket accepted=acceptor.accepted();
+			TcpConnection connection=new TcpConnection(accepted,listener);
+			try {
+				send(client,"error: some broken data");
+				// Note: Wait for the data to be processed, so that it is not delivered together with the
+				// data sent next, which the connection has to survive to.
+				assertTrue(failed.await(TIMEOUT_MS,TimeUnit.MILLISECONDS),"The broken data has not been received.");
+
+				send(client,"regular data");
+				assertEquals("regular data",awaitFirst(processed),
+					"The connection handler has been terminated by data that could not be processed.");
+				assertTrue(connection.isRunning(),"The connection handler has been terminated.");
+			}
+			finally {
+				connection.halt();
+			}
+		}
+	}
+
+	/**
+	 * A connection that cannot be handled must neither terminate the server, since that would stop
+	 * accepting connections at all, nor leak the accepted socket.
+	 */
+	@Test
+	void testServerSurvivesFailureWhileHandlingConnection() throws IOException, InterruptedException {
+		AtomicBoolean first_connection=new AtomicBoolean(true);
+		BlockingQueue<TcpSocket> refused=new ArrayBlockingQueue<>(1);
+		BlockingQueue<TcpSocket> accepted=new ArrayBlockingQueue<>(1);
+
+		TcpServerListener listener=new TcpServerListener() {
+			@Override
+			public void onIncomingConnection(TcpServer server, TcpSocket socket) {
+				if (first_connection.compareAndSet(true,false)) {
+					refused.add(socket);
+					throw new OutOfMemoryError("Simulated failure while handling a connection.");
+				}
+				accepted.add(socket);
+			}
+
+			@Override
+			public void onServerTerminated(TcpServer server, Exception error) {
+				// Ignore.
+			}
+		};
+
+		TcpServer server=new TcpServer(serverSocket(),listener);
+		try (TcpSocket first=new TcpSocket(LOCALHOST,server.getPort())) {
+			TcpSocket refused_socket=poll(refused);
+			assertNotNull(refused_socket,"The first connection has not been handled.");
+			assertEquals(-1,readByte(first),"The refused connection must be closed by the server.");
+
+			try (TcpSocket second=new TcpSocket(LOCALHOST,server.getPort())) {
+				assertNotNull(poll(accepted),"The server stopped accepting connections.");
+				assertTrue(server.isRunning(),"The server has been terminated.");
+			}
+		}
+		finally {
+			server.halt();
+		}
+	}
+
+	// **************************** Utilities ****************************
+
+	/**
+	 * A server socket bound to an ephemeral port of the loopback interface.
+	 * <p>
+	 * Note: {@link TcpServer#getPort()} reports the port passed to its constructor, so a
+	 * {@link TcpServer} created for port 0 does not report the port it is actually listening to.
+	 * </p>
+	 */
+	private static ServerSocket serverSocket() throws IOException {
+		return new ServerSocket(0,TcpServer.DEFAULT_SOCKET_BACKLOG,InetAddress.getLoopbackAddress());
+	}
+
+	private static void send(TcpSocket socket, String data) throws IOException {
+		socket.getOutputStream().write(data.getBytes(StandardCharsets.UTF_8));
+		socket.getOutputStream().flush();
+	}
+
+	/** Reads a single byte, or -1 if the remote end has closed the connection. */
+	private static int readByte(TcpSocket socket) throws IOException {
+		socket.setSoTimeout(TIMEOUT_MS);
+		InputStream in=socket.getInputStream();
+		return in.read();
+	}
+
+	private static TcpSocket poll(BlockingQueue<TcpSocket> queue) throws InterruptedException {
+		return queue.poll(TIMEOUT_MS,TimeUnit.MILLISECONDS);
+	}
+
+	/** Waits for the first element of the given list. */
+	private static String awaitFirst(List<String> values) throws InterruptedException {
+		for (long end=System.currentTimeMillis()+TIMEOUT_MS; System.currentTimeMillis()<end;) {
+			synchronized (values) {
+				if (!values.isEmpty()) return values.get(0);
+			}
+			Thread.sleep(10);
+		}
+		return null;
+	}
+
+	/** A TCP server accepting a single connection. */
+	private static class Acceptor implements AutoCloseable {
+
+		private final BlockingQueue<TcpSocket> _accepted=new ArrayBlockingQueue<>(1);
+
+		private final TcpServer _server;
+
+		Acceptor() throws IOException {
+			_server=new TcpServer(serverSocket(),new TcpServerListener() {
+				@Override
+				public void onIncomingConnection(TcpServer server, TcpSocket socket) {
+					_accepted.add(socket);
+				}
+
+				@Override
+				public void onServerTerminated(TcpServer server, Exception error) {
+					// Ignore.
+				}
+			});
+		}
+
+		int getPort() {
+			return _server.getPort();
+		}
+
+		TcpSocket accepted() throws InterruptedException {
+			TcpSocket socket=poll(_accepted);
+			assertNotNull(socket,"No connection has been accepted.");
+			return socket;
+		}
+
+		@Override
+		public void close() {
+			_server.halt();
+		}
+
+	}
+
+}


### PR DESCRIPTION
Third and last part of the scan that started with #39: the two TCP receive loops have the structure that made the `Content-Length` bug fatal — the listener is called inside a `try` whose `catch` sits outside the loop, and it does not cover `Error`.

## `TcpConnection.run()`

It caught only `IOException` (`:198`), with `listener.onReceivedData` inside the guarded block. An `Error` thrown while processing received data left `run()` without executing *any* of its cleanup:

- `is_running=false` skipped, so the connection kept reporting itself as running,
- the streams were not closed,
- `onConnectionTerminated` was never fired, so nothing above ever learned about it and the socket leaked.

To be precise about reachability: `SipProvider.onReceivedMessage` wraps SIP dispatch in `catch (Exception)`, so a `RuntimeException` from message processing cannot get this far. This is `Error`-only in practice — which is exactly the case that made the original bug a permanent denial of service rather than a dropped packet.

## `TcpServer.run()`

Same structure around the whole accept loop (`:163`), with a larger blast radius: a failure while handling a *single* incoming connection stopped the server from accepting **any** further connection, and left the accepted socket open. `TcpTransport.processIncomingConnection` only catches `IOException`.

## The change

A failure while handling one connection or one chunk of data is logged and no longer affects the loop — the same per-item guard `UdpProvider` now has. A connection that cannot be handled is closed instead of leaked. The outer handlers catch `Throwable` so the termination bookkeeping and callbacks always run, and `TcpServer` reports its termination to the log instead of dumping a stack trace to standard error.

## Tests

`TestTcpReceiveLoops` drives both loops over the loopback interface with a listener that throws `OutOfMemoryError`:

- **Connection**: broken data first, then valid data. It waits for the failing callback before sending the second chunk, so TCP cannot coalesce the two into one read and the test stays deterministic. Asserts the valid data is processed and the handler still runs.
- **Server**: the first connection is refused by a throwing listener, the second must still be accepted. Asserts the refused socket was closed by reading `-1` on the client side — that is the leak, checked through observable behaviour rather than internal state.

Verified against the unfixed loops: the server test fails with `SocketTimeoutException: Read timed out` (the refused socket stays open) and the connection test fails because the valid data is never processed. `mvn test` is green across the reactor.

## Left out of this change

- #44 — `TcpServer.getPort()` reports the requested port, not the bound one, so a server created for port 0 cannot be connected to. `TestTcpReceiveLoops` works around it by passing a pre-bound `ServerSocket`; the workaround is commented in the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
