### PR TITLE
Report the port a TcpServer is actually listening to

### DIFF
--- a/mjsip-net/src/main/java/org/zoolu/net/TcpServer.java
+++ b/mjsip-net/src/main/java/org/zoolu/net/TcpServer.java
@@ -107,13 +107,15 @@ public class TcpServer extends Thread {
 	/** Inits the TcpServer */
 	private void init(ServerSocket server_socket, int port, IpAddress bind_ipaddr, long alive_time, TcpServerListener listener) throws java.io.IOException {
 		this.listener=listener;
-		this.server_port=port;
 		this.server_ipaddr=bind_ipaddr;
 		if (server_socket==null) {
 			if (bind_ipaddr==null) server_socket=new ServerSocket(port);
 			else server_socket=new ServerSocket(port,DEFAULT_SOCKET_BACKLOG,bind_ipaddr.getInetAddress());
 		}
 		this.server_socket=server_socket;
+		// Note: The port is taken from the socket, since the port requested may be 0, in which case the
+		// server is listening to a port assigned by the operating system.
+		this.server_port=server_socket.getLocalPort();
 		this.socket_timeout=DEFAULT_SOCKET_TIMEOUT;
 		this.alive_time=alive_time;
 		this.stop=false; 

--- a/mjsip-net/src/test/java/test/org/zoolu/net/TestTcpReceiveLoops.java
+++ b/mjsip-net/src/test/java/test/org/zoolu/net/TestTcpReceiveLoops.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
-import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -113,7 +112,7 @@ class TestTcpReceiveLoops {
 			}
 		};
 
-		TcpServer server=new TcpServer(serverSocket(),listener);
+		TcpServer server=new TcpServer(0,LOCALHOST,listener);
 		try (TcpSocket first=new TcpSocket(LOCALHOST,server.getPort())) {
 			TcpSocket refused_socket=poll(refused);
 			assertNotNull(refused_socket,"The first connection has not been handled.");
@@ -129,18 +128,19 @@ class TestTcpReceiveLoops {
 		}
 	}
 
-	// **************************** Utilities ****************************
+	/** A server listening to a port assigned by the operating system must report that port. */
+	@Test
+	void testEphemeralPort() throws IOException, InterruptedException {
+		try (Acceptor acceptor=new Acceptor()) {
+			assertTrue(acceptor.getPort()>0,"No port assigned: "+acceptor.getPort());
 
-	/**
-	 * A server socket bound to an ephemeral port of the loopback interface.
-	 * <p>
-	 * Note: {@link TcpServer#getPort()} reports the port passed to its constructor, so a
-	 * {@link TcpServer} created for port 0 does not report the port it is actually listening to.
-	 * </p>
-	 */
-	private static ServerSocket serverSocket() throws IOException {
-		return new ServerSocket(0,TcpServer.DEFAULT_SOCKET_BACKLOG,InetAddress.getLoopbackAddress());
+			try (TcpSocket client=new TcpSocket(LOCALHOST,acceptor.getPort())) {
+				assertEquals(acceptor.getPort(),acceptor.accepted().getLocalPort());
+			}
+		}
 	}
+
+	// **************************** Utilities ****************************
 
 	private static void send(TcpSocket socket, String data) throws IOException {
 		socket.getOutputStream().write(data.getBytes(StandardCharsets.UTF_8));
@@ -177,7 +177,7 @@ class TestTcpReceiveLoops {
 		private final TcpServer _server;
 
 		Acceptor() throws IOException {
-			_server=new TcpServer(serverSocket(),new TcpServerListener() {
+			_server=new TcpServer(0,LOCALHOST,new TcpServerListener() {
 				@Override
 				public void onIncomingConnection(TcpServer server, TcpSocket socket) {
 					_accepted.add(socket);


### PR DESCRIPTION
Fixes #44.

**Stacked on #41** (`harden-tcp-receive-loops`), whose test contains the workaround this removes. Merge #41 first; GitHub will then retarget this to `master`.

`init()` took the server port from its `port` argument instead of from the bound socket, so a server created for port 0 reported 0 rather than the port assigned by the operating system. `getPort()` and `toString()` both lied, and connecting to the reported port failed with `ConnectException: Connection refused`. The port is now read from the socket, after it exists. `TlsServer` inherits the fix, since it extends `TcpServer`.

The `TcpServer(ServerSocket, listener)` constructor was already correct — it reads `getLocalPort()` — which is why `TestTcpReceiveLoops` could work around the bug by passing a pre-bound `ServerSocket`.

## Tests

That workaround is now gone: both existing tests construct `new TcpServer(0, LOCALHOST, listener)` directly, so they exercise the fix as a side effect, and `serverSocket()` along with its explanatory comment is deleted. Added `testEphemeralPort`, asserting the reported port is non-zero and matches the local port of the accepted connection.

Verified against the unfixed code: `testEphemeralPort` fails with `No port assigned: 0` and the other two now fail with `ConnectException: Connection refused` — the failure that made the workaround necessary in the first place. `mvn test` green across the reactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)