### PR TITLE
Fix the packet length bookkeeping of RtpPacket and RtcpCompoundPacket

### DIFF
--- a/mjsip-sip/src/main/java/org/mjsip/rtp/RtcpCompoundPacket.java
+++ b/mjsip-sip/src/main/java/org/mjsip/rtp/RtcpCompoundPacket.java
@@ -44,10 +44,12 @@ public class RtcpCompoundPacket {
 
 
 
-	/** Creates a new RtcpCompoundPacket. */ 
+	/** Creates a new RtcpCompoundPacket containing the whole given buffer.
+	  * @param buffer packet buffer */
 	public RtcpCompoundPacket(byte[] buffer) {
 		this.buffer=buffer;
 		this.offset=0;
+		this.length=buffer.length;
 	}
 
 	/** Creates a new RtcpCompoundPacket.

--- a/mjsip-sip/src/main/java/org/mjsip/rtp/RtpPacket.java
+++ b/mjsip-sip/src/main/java/org/mjsip/rtp/RtpPacket.java
@@ -208,13 +208,17 @@ public class RtpPacket {
 	}
 
 	/** Sets padding length.
+	  * The packet is extended to hold the padding, keeping its payload.
 	  * @param padding_len the number of padding bytes */
 	public void setPaddingLength(int padding_len) {
 		if (length<HDR_LEN) return; // broken packet
 		// else
 		if (padding_len>0)  {
-			int pl_len=getPayloadLength();
 			int hdr_len=getHeaderLength();
+			int pl_len=getPayloadLength();
+			// Note: The padding has to be part of the packet, otherwise it is neither sent nor found
+			// again by getPaddingLength().
+			setPacketLength(hdr_len+pl_len+padding_len);
 			for (int i=0; i<padding_len-1; i++) buffer[offset+hdr_len+pl_len+i]=0;
 			buffer[offset+hdr_len+pl_len+padding_len-1]=(byte)padding_len;
 			BufferUtil.setBit(true, buffer, offset, 5);

--- a/mjsip-sip/src/test/java/org/mjsip/rtp/TestRtcpPacket.java
+++ b/mjsip-sip/src/test/java/org/mjsip/rtp/TestRtcpPacket.java
@@ -123,6 +123,23 @@ class TestRtcpPacket {
 		assertEquals(0,packets[0].getPacketOffset());
 	}
 
+	/** A compound packet created for a buffer covers that whole buffer. */
+	@Test
+	void testCompoundPacketForBuffer() {
+		byte[] buffer=new byte[36];
+		RtcpPacket first=new RtcpPacket(buffer,0);
+		first.setVersion(2);
+		first.setPacketLength(8);
+		RtcpPacket second=new RtcpPacket(buffer,8);
+		second.setVersion(2);
+		second.setPacketLength(28);
+
+		RtcpCompoundPacket compound=new RtcpCompoundPacket(buffer);
+
+		assertEquals(buffer.length,compound.getPacketLength());
+		assertEquals(2,compound.getRtcpPackets().length);
+	}
+
 	/** A trailing fragment shorter than a RTCP header must be dropped. */
 	@Test
 	void testCompoundPacketWithTrailingFragment() {

--- a/mjsip-sip/src/test/java/org/mjsip/rtp/TestRtpPacket.java
+++ b/mjsip-sip/src/test/java/org/mjsip/rtp/TestRtpPacket.java
@@ -45,6 +45,33 @@ class TestRtpPacket {
 		assertArrayEquals(payload,packet.getPayload());
 	}
 
+	/** The padding has to become part of the packet, so that it is sent and found again. */
+	@Test
+	void testSetPaddingLength() {
+		byte[] payload={ 1, 2, 3, 4, 5 };
+		RtpPacket packet=new RtpPacket(0,4711,1,0,payload,0,payload.length);
+		packet.setPaddingLength(4);
+
+		assertEquals(HDR_LEN+payload.length+4,packet.getPacketLength());
+		assertEquals(4,packet.getPaddingLength());
+		assertEquals(payload.length,packet.getPayloadLength());
+		assertArrayEquals(payload,packet.getPayload());
+		assertPayloadWithinPacket(packet);
+	}
+
+	/** Setting the padding again must replace the padding set before. */
+	@Test
+	void testResetPaddingLength() {
+		byte[] payload={ 1, 2, 3, 4, 5 };
+		RtpPacket packet=new RtpPacket(0,4711,1,0,payload,0,payload.length);
+		packet.setPaddingLength(4);
+		packet.setPaddingLength(8);
+
+		assertEquals(HDR_LEN+payload.length+8,packet.getPacketLength());
+		assertEquals(8,packet.getPaddingLength());
+		assertArrayEquals(payload,packet.getPayload());
+	}
+
 	/** A received packet with four bytes of payload followed by four bytes of padding. */
 	@Test
 	void testPacketWithPadding() {


### PR DESCRIPTION
Fixes #42 and #43, the two sender-side bugs found while writing the tests for #40.

Replaces #45, which was closed automatically when its base branch `fix-rtp-length-validation` was deleted after #40 merged. Same two commits, rebased onto `master`; the branch no longer depends on anything unmerged.

## #42 — `RtpPacket.setPaddingLength()` wrote the padding outside the packet

It appended the padding after the payload without extending `length`, so for a packet of `12 + 8` bytes, `setPaddingLength(4)` wrote the padding length to index 23 while the packet still claimed to end at index 19. The padding was therefore neither sent nor found again by `getPaddingLength()` (which reads the last byte of the packet, giving 0), and with a tightly sized buffer the write went past the buffer end. Only the P bit was set correctly — the packet announced a padding it did not contain.

The packet is now extended via `setPacketLength()` before the padding is written, so setting the padding again replaces the previous one instead of appending. `setPaddingLength(0)` keeps clearing just the P bit, so `setPayloadLength()` — which sets the length first and then clears the padding — behaves as before.

## #43 — `RtcpCompoundPacket(byte[])` left the length at 0

The constructor set the buffer and the offset but not `length`, so the packet reported no length and `getRtcpPackets()` returned an empty array for any buffer. It now covers the whole buffer, consistent with the other constructors.

## Tests

Three tests added to the suites from #40; `mvn test` green across the reactor (`mjsip-sip` at 74 with all merged work).

- `testSetPaddingLength` — padding is part of the packet, payload preserved, packet grew by the padding length.
- `testResetPaddingLength` — setting the padding twice replaces it rather than appending.
- `testCompoundPacketForBuffer` — a compound packet built from a buffer covers it and finds both contained packets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)